### PR TITLE
Minimum Viable Model v1.0.0 for MVP+ releasee

### DIFF
--- a/model-desc/popsci-model-props.yml
+++ b/model-desc/popsci-model-props.yml
@@ -589,8 +589,8 @@ PropDefinitions:
   participant_case_indicator:
     Desc: <A response to indicate whether or not the participant is a case in the study in question.> <br>CDE ID = 14883047
     Term:
-      - Origin: TBD
-        Code: '14883047'
+      - Origin: x
+        Code: 'y' # TBD as of 12-09-25
         Value: Subject Participant Case Indicator
         Version: '1' # ?    
     Src: Data Submitter(s)

--- a/model-desc/popsci-model-props.yml
+++ b/model-desc/popsci-model-props.yml
@@ -63,7 +63,6 @@ PropDefinitions:
   #     value_type: list
   #     item_type: string
   #  Req: 'Yes'  
-
   # program properties
   # program_name:
   #   Desc: <The narrative title used to refer to a broad framework (an administrative umbrella) of goals under which related projects or other research activities are grouped. Example - Clinical Proteomic Tumor Analysis.> <br>CDE ID = 11444542 
@@ -161,40 +160,6 @@ PropDefinitions:
     Req: 'Yes'
     Tags:
       Labeled: Description
-  # study_type: 
-  #   Desc: A classification of the study based upon the primary intent of the study's activities. <br>CDE ID = 11160683
-  #   Term:
-  #     - Origin: caDSR - CRDC
-  #       Code: '11160683'
-  #       Value: Study Primary Purpose Type 
-  #   Src: DSS
-  #   Enum:
-  #     - Adverse Effect Mitigation Study 
-  #     - Ancillary Study
-  #     - Basic Science Research
-  #     - Correlative Study
-  #     - Cure Study
-  #     - Device Feasibility Study
-  #     - Diagnosis Study
-  #     - Disease Modifying Treatment Study
-  #     - Early Detection Study
-  #     - Education Training Clinical Study
-  #     - Epidemiology Research 
-  #     - Genomics Research
-  #     - Health Services Research
-  #     - Imaging Research
-  #     - Observational Study
-  #     - Outcomes Research
-  #     - Prevention Study
-  #     - Proteomic Research
-  #     - Rehabilitation Clinical Study
-  #     - Screening Study
-  #     - Supportive Care Study
-  #     - Transcriptomics Research
-  #     - Treatment Study
-  #   Req: 'Yes'
-  #   Tags:
-  #     Labeled: Study Type
   study_design: 
     Desc: Text here <br>NOT CURRENTLY ASSIGNED ANY CDE
     Term:
@@ -202,8 +167,7 @@ PropDefinitions:
         Code: 'code/ID'
         Value: Data Element Name 
     Src: Data Submitter(s)
-    Enum:
-      # Acceptable values listed below are the actual values propsed by the working group
+    Enum: # Acceptable values listed below are the actual values propsed by the working group
       - Case Series Study # Cases are not compared to subjects without the manifestations of interest; Case Series studies are primarily descriptive reports observed in groups under study.
       - Case-Control Study # Patients who already have a certain condition are compared with people who do not
       - Nested Case-Control Study
@@ -268,18 +232,7 @@ PropDefinitions:
         Value: Data Element Name  
     Src: Data Submitter(s)c
     Type: string # this accomodates use of the the term Ongoing for studies that are still active
-    Req: 'Yes'    
-  # number_of_participants: # this will no longer be needed with participant records loaded, from which the study-specific participant counts can be derived
-  #   Desc: The total number of participants included in the study as of its submission. <br>NOT CURRENTLY ASSIGNED ANY CDE
-  #   Term:
-  #     - Origin: caDSR
-  #       Code: 'code/ID'
-  #       Value: Data Element Name  
-  #   Src: Data Submitter(s)
-  #   Type: integer
-  #   Req: 'Yes'
-  #   Tags:
-  #     Labeled: Participant Count
+    Req: 'Yes'
   biospecimen_collection:
     Desc: A Boolean indication as to whether the study in question included the collection of biospecimens from any of the participants enrolled in the study, that gives no indication as to the type and/or number of any such biospecimens. <br>NOT CURRENTLY ASSIGNED ANY CDE
     Src: Data Submitter(s)
@@ -333,17 +286,6 @@ PropDefinitions:
     Req: 'No'
     Tags:
       Labeled: Full Name
-  # person_orcid_id:
-  #   Desc: A persistent unique digital identifier assigned to a principal investigator by the Open Researcher and Contributor ID (ORCID) organization. <br>CDE ID = 10624734
-  #   Term:
-  #     - Origin: caDSR - CRDC
-  #       Code: '10624734'
-  #       Value: Person ORCID Text
-  #   Src: DSS
-  #   Type: string
-  #   Req: Preferred
-  #   Tags:
-  #     Labeled: ORCID ID
   person_institution:
     Desc: text here <br>NOT CURRENTLY ASSIGNED ANY CDE
     Term:
@@ -355,17 +297,6 @@ PropDefinitions:
     Req: 'Yes'
     Tags:
       Labeled: Institution
-  # person_email_address:
-  #   Desc: text <br>NOT CURRENTLY ASSIGNED ANY CDE
-  #   Term:
-  #     - Origin: caDSR
-  #       Code: 'code/ID'
-  #       Value: Data Element Name  
-  #   Src: Data Submitter(s)
-  #   Type: string
-  #   Req: Preferred
-  #   Tags:
-  #     Labeled: Email Address
   person_role:
     Desc: <The text that describes the distinguishable characteristics of the action or activity assigned to or required or expected of a person in a formal association with a group or organization.> An indicator as to the role(s) and/or responsibilities of each individual responsible for or directly involved in the conduct and/or analysis of the clinical trial or research project. Each such individual must have at least one specified role, but any given indivdual may be assigned multiple roles for the study in question. Within the data loading file, multiple roles assigned to a single individual must be separated from one another using the pipe (|) character. <br>CDE ID = 2201713
     Term:
@@ -525,213 +456,6 @@ PropDefinitions:
     Req: 'Yes'
     Tags:
       Labeled: States, Provinces and Territories
-  # study_demographic properties
-  # study_demographic_record_id:
-  #   Desc: <A unique sequence of characters used to identify a linkage between related records.> A unique identifier of each demographic record, used to identify the appropriate demographic record(s) during data loading and/or record modification. <br>CDE ID = 14822135
-  #   Term:
-  #     - Origin: caDSR - CTDC
-  #       Code: '14822135'
-  #       Value: Data Record Link Unique Identifier 
-  #   Src: Data Submitter(s)
-  #   Type: string
-  #   Req: 'Yes'
-  #   Key: true
-  # study_participant_minimum_age:
-  #   Desc: text here <br>NOT CURRENTLY ASSIGNED ANY CDE
-  #   Term:
-  #     - Origin: caDSR
-  #       Code: 'code/ID'
-  #       Value: Data Element Name  
-  #   Src: Data Submitter(s)
-  #   Type: integer
-  #   Req: 'Yes'
-  #   Tags:
-  #     Labeled: Minimum Participant Age
-  # study_participant_maximum_age:
-  #   Desc: text here <br>NOT CURRENTLY ASSIGNED ANY CDE
-  #   Term:
-  #     - Origin: caDSR
-  #       Code: 'code/ID'
-  #       Value: Data Element Name  
-  #   Src: Data Submitter(s)
-  #   Type: integer
-  #   Req: 'Yes'
-  #   Tags:
-  #     Labeled: Maximum Participant Age 
-  # study_participant_median_age:
-  #   Desc: text here <br>NOT CURRENTLY ASSIGNED ANY CDE
-  #   Term:
-  #     - Origin: caDSR
-  #       Code: 'code/ID'
-  #       Value: Data Element Name  
-  #   Src: Data Submitter(s)
-  #   Type: number
-  #   Req: 'Yes'
-  #   Tags:
-  #     Labeled: Median Participant Age 
-  # race:
-  #   Desc: <The text for reporting information about race based on the Office of Management and Budget (OMB) categories.> This list type property accepts multiple values for the races represented within any given study population, provided that each value specified is included in the associated controlled vocabulary of acceptable terms. Within the data loading file for the Study Demographic node, multiple race values must be separated from one another using the pipe (|) character. <br>CDE ID = 2192199
-  #   Term:
-  #     - Origin: caDSR - OMB/NCI Standard
-  #       Code: '2192199'
-  #       Value: Subject Race
-  #       Version: '1'
-  #   Src: Data Submitter(s)
-  #   Type:
-  #     value_type: list
-  #     Enum: # now fully aligned with the acceptable values for the corresponding CDE
-  #       - American Indian or Alaska Native
-  #       - Asian #added 04-15-25
-  #       - Black or African American
-  #       - Native Hawaiian or other Pacific Islander
-  #       - Not allowed to collect # added 04-11-25
-  #       - Not Reported
-  #       - Unknown
-  #       - White
-  #   Req: 'Yes'
-  #   Tags:
-  #     Labeled: Race, Particpant Races
-  # ethnicity:
-  #   Desc: The text for reporting information about ethnicity based on the Office of Management and Budget (OMB) categories.> This list type property accepts multiple values for the ethnicities represented within any given study population, provided that each value specified is included in the associated controlled vocabulary of acceptable terms. Within the data loading file for the Study Demographic node, multiple ethnicity values must be separated from one another using the pipe (|) character. <br>CDE ID = 2192217
-  #   Term:
-  #     - Origin: caDSR - OMB/NCI Standard
-  #       Code: '2192217'
-  #       Value: Ethnic Group Category Text
-  #       Version: '2'
-  #   Src: CMB
-  #   Type:
-  #     value_type: list
-  #     Enum: # now fully aligned with the acceptable values for the corresponding CDE
-  #       - Hispanic or Latino
-  #       - Not allowed to collect # added 04-15-25
-  #       - Not Hispanic or Latino
-  #       - Not reported
-  #       - Unknown
-  #   Req: 'Yes'
-  #   Tags:
-  #     Labeled: Ethnicity, Participant Ethnicities
-  # sex:
-  #   Desc: <A textual description of a person's sex at birth.>  This list type property accepts multiple values for the sexes represented within any given study population, provided that each value specified is included in the associated controlled vocabulary of acceptable terms. Within the data loading file for the Study Demographic node, multiple sex values must be separated from one another using the pipe (|) character. <br>CDE ID = 7572817
-  #   Term:
-  #     - Origin: caDSR - NCI Standards
-  #       Code: '7572817'
-  #       Value: Person Sex at Birth Category
-  #       Version: '2'
-  #   Src: CMB
-  #   Type:
-  #     value_type: list
-  #     Enum: # now fully aligned with the acceptable values for the corresponding CDE
-  #       - Female
-  #       #- Intersex removed 04-15-25
-  #       - Male
-  #       - Unknown
-  #   Req: 'Yes'
-  #   Tags:
-  #     Labeled: Sex, Participant Sexes
-  # gender:
-  #   Desc: Characteristics of people that are socially constructed, including norms, behaviors, and roles based on their sex. As a social construct, these norms, behaviors, and roles vary from society to society and can change over time. <br>CDE ID = 10748236
-  #   Term:
-  #     - Origin: caDSR - CRDC
-  #       Code: '10748236'
-  #       Value: Person Reported Gender Type  
-  #   Src: DSS
-  #   Type:
-  #     value_type: list
-  #     Enum:
-  #       # - Choose Not to Disclose # = Response Declined per CMB?
-  #       - Female # per CMB data values
-  #       # - Female-To-Male
-  #       - Female-to-Male Transsexual # per CMB data values
-  #       - Intersex # per CMB data values
-  #       - Male # per CMB data values
-  #       # - Male-To-Female
-  #       - Male-to-Female Transsexual # per CMB data values
-  #       # - None Of These Describe Me
-  #       # - Non-Conforming Gender
-  #       #- Refused to Answer # = Response Declined per CMB?
-  #       - Response Declined # per CMB data values
-  #       - Unknown # per CMB data values
-  #   Req: 'Yes'
-  #   Tags:
-  #     Labeled: Gender Representation
-  # ncbi_taxonomy_id:
-  #   Desc: A label provided by NCBI Taxonomy Database (https://www.ncbi.nlm.nih.gov/taxonomy/),  which uniquely identifies group or category, at any level, in a system for classifying plants or animals (including humans) providing ranked categories for the classification of organisms according to their suspected evolutionary relationships. For human study participants, the value of this ID will be 9606. <br>CDE ID = 10543100
-  #   Term:
-  #     - Origin: caDSR - CRDC
-  #       Code: '10543100'
-  #       Value: Subject National Center for Biotechnology Information Taxonomy Identifier Integer
-  #   Src: DSS
-  #   Type: integer # not enumerated
-  #   Req: 'Yes'
-  # ncbi_taxonomy_name:
-  #   Desc: The textual label associated with a subject's organismal classification as captured in the National Center for Biotechnology Information (NCBI) Taxonomy standard nomenclature and classification repository. For human study participants, the value of this property will be Homo sapiens. <br>Supposedly enumerated but no permissible values specified. <br>CDE ID = 10543082
-  #   Term:
-  #     - Origin: caDSR - CRDC
-  #       Code: '10543082'
-  #       Value: Subject National Center for Biotechnology Information Taxonomy Name Text
-  #   Src: DSS
-  #   Type: string # supposedly enumerated but no permissible values specified
-  #   Req: 'Yes'  
-  # primary_diagnosis properties
-  # primary_diagnosis_record_id:
-  #   Desc: <A unique sequence of characters used to identify a linkage between related records.> A unique identifier of each primary diagnosis record associated with the study in question, used to identify the appropriate primary diagnosis record(s) during data loading and/or record modification. <br>CDE ID = 14822135
-  #   Term:
-  #     - Origin: caDSR - CTDC
-  #       Code: '14822135'
-  #       Value: Data Record Link Unique Identifier
-  #   Src: PSc
-  #   Type: string
-  #   Req: 'Yes'
-  #   Key: true
-  # primary_diagnosis_disease_term:
-  #   Desc: text here <br>NOT CURRENTLY ASSIGNED ANY CDE
-  #   Term:
-  #     - Origin: caDSR
-  #       Code: 'code/ID'
-  #       Value: Data Element Name  
-  #   Src: CMB
-  #   Enum: # Examples of the ctep_disease_term values used by the CMB
-  #     - Acute Myeloid Leukemia Not Otherwise Specified  # meddra code 10000884
-  #     - Adenocarcinoma of the Gastroesophageal Junction # meddra code 10066354
-  #     - Colorectal Carcinoma                            # meddra code 10010029
-  #     - Invasive Breast Carcinoma                       # meddra code 10006190 NEW
-  #     - Melanoma                                        # meddra code 10053571 
-  #     - Non-Small Cell Lung Carcinoma                   # meddra code 10029514
-  #     - Ovarian Carcinoma                               # meddra code 10033159 NEW
-  #     - Plasma Cell Myeloma                             # meddra code 10028566 
-  #     - Prostate Carcinoma                              # meddra code 10036910 
-  #     - Small Cell Lung Carcinoma                       # meddra code 10041071
-  #   Req: 'Yes'
-  #   Tags:
-  #     Labeled: Primary Diagnoses Examined
-  # comorbidity properties
-  # comorbidity_record_id:
-  #   Desc: <A unique sequence of characters used to identify a linkage between related records.> A unique identifier of each comorbidity record associated with the study in question, used to identify the appropriate comorbidity record(s) during data loading and/or record modification. <br>CDE ID = 14822135
-  #   Term:
-  #     - Origin: caDSR - CTDC
-  #       Code: '14822135'
-  #       Value: Data Record Link Unique Identifier
-  #   Src: PSc
-  #   Type: string
-  #   Req: 'Yes'
-  #   Key: true
-  # comorbidity_disease_term:
-  #   Desc: text here <br>NOT CURRENTLY ASSIGNED ANY CDE
-  #   Term:
-  #     - Origin: caDSR
-  #       Code: 'code/ID'
-  #       Value: Data Element Name  
-  #   Src: PSc
-  #   Enum: # NEED LIST OF ACCEPTABLE TERMS HERE - these are purely random examples
-  #     - Chronic Respiratory Illness
-  #     - Heart Disease
-  #     - Kidney Disease
-  #     - Inflammatory Bowel Disease
-  #     - Crohn's Disease
-  #   Req: 'Yes'
-  #   Tags:
-  #     Labeled: Comorbities Examined
-  # data_collection properties
   data_collection_record_id:
     Desc: <A unique sequence of characters used to identify a linkage between related records.> A unique identifier of each data collection record associated with the study in question, used to identify the appropriate data collection record(s) during data loading and/or record modification. <br>CDE ID = 14822135
     Term:
@@ -742,19 +466,6 @@ PropDefinitions:
     Type: string
     Req: 'Yes'
     Key: true
-  # data_collection_grouping:
-  #   Desc: text here <br>NOT CURRENTLY ASSIGNED ANY CDE
-  #   Term:
-  #     - Origin: caDSR
-  #       Code: 'code/ID'
-  #       Value: Data Element Name  
-  #   Src: PSc
-  #   Enum:
-  #     - Lifestyle and Behaviors
-  #     - Socio-demograhic and Economic Characteristics
-  #     - Diseases
-  #     - Etc
-  #   Req: 'No'
   data_collection_category:
     Desc: text here <br>NOT CURRENTLY ASSIGNED ANY CDE
     Term:
@@ -763,7 +474,7 @@ PropDefinitions:
         Value: Data Element Name 
     Src: PSc
     Enum: # n=71
-      - Age #Demographics / Lifestyle / Life events / Quality of life
+      - Age # Demographics / Lifestyle / Life events / Quality of life
       - Biological Sex
       - Sexual Orientation and Gender Identity
       - Ethnicity and Race
@@ -776,27 +487,27 @@ PropDefinitions:
       - Quality of Life
       - Social Support
       - Socio-Economic Status
-      - Alcohol Consumption #Alcohol / Tobacco / Drug Use
+      - Alcohol Consumption # Alcohol / Tobacco / Drug Use
       - Cigarette Smoking
       - Other Tobacco Products
       - Drug Use
-      - Dietary Intake #Diet / Nutrition
+      - Dietary Intake # Diet / Nutrition
       - Dietary Supplement Use
-      - Physical Activity #Physical Activity / Energy Balance
+      - Physical Activity # Physical Activity / Energy Balance
       - Physical Function Measures
       - Self-Reported Anthropometry #Anthropometry
       - Measured Anthropometry
-      - Puberty, Menstruation, and Menopause #Reproductive Health History
+      - Puberty, Menstruation, and Menopause # Reproductive Health History
       - Pregnancy and Parity
       - Breastfeeding
       - Contraception
       - Hormone Replacement
       - Sexual Behavior and Health
-      - Housing Exposures #Environmental or Occupational Exposures
+      - Housing Exposures # Environmental or Occupational Exposures
       - Workplace Exposures
       - Radiation Exposure
       - Chemical Exposure
-      - Health Insurance Status #Medical / Health Status / Health History
+      - Health Insurance Status # Medical / Health Status / Health History
       - Screening
       - Immunization
       - Sleep Habits
@@ -837,22 +548,6 @@ PropDefinitions:
     Req: 'Yes'
     Tags:
       Labeled: Data Collection Categories
-  # data_collection_category_annotation_coverage:
-  #   Desc: text here <br>NOT CURRENTLY ASSIGNED ANY CDE
-  #   Term:
-  #     - Origin: caDSR
-  #       Code: 'code/ID'
-  #       Value: Data Element Name 
-  #   Src: FNL
-  #   Enum: 
-  #     - None
-  #     - Minimal
-  #     - Detailed
-  #     - Extensive
-  #     - Low
-  #     - Medium
-  #     - High
-  #   Req: Preferred
   data_collection_category_annotation_count: # subject to confirmation from the working group, this property will morph into a binary Yes versus No indicator as to whether the data collection category in question was examined or not, given that the reporting of the number of variables per data collection category will be too burdensome
     Desc: Pending additional data model and application code changes, this property functions as a binary indicator as to whether variables associated with any given data collection were assessed or not. A value of 0 should be used to indicate that no variables associated with a given data collection category were assessed. Whereas regradless of how many variables within a data collection category were assessed, a value of 1 should be used simply to indicate that variables associated with a given data collection category were indeed assessed. <br>NOT CURRENTLY ASSIGNED ANY CDE
     Term:
@@ -913,54 +608,6 @@ PropDefinitions:
     Type:
       value_type: list
       item_type: string
-      # Enum: # example values for primary site copied directly from the ICDC data model listed below are to be used only for the generation of mock data
-      # - Abdomen
-      # - Bladder
-      # - Bladder, Prostate
-      # - Bladder, Urethra
-      # - Bladder, Urethra, Prostate
-      # - Bladder, Urethra, Vagina
-      # - Bone
-      # - Bone (Appendicular)
-      # - Bone (Axial)
-      # - Bone Marrow
-      # - Brain
-      # - Carpus
-      # - Chest Wall
-      # - Cranial Sternum
-      # - Distal Urethra
-      # - Elbow Joint
-      # - Femur
-      # - Flank
-      # - Hip
-      # - Hock
-      # - Humerus
-      # - Inguinal Region
-      # - Kidney
-      # - Knee Region
-      # - Lip
-      # - Lung
-      # - Lymph Node
-      # - Mammary Gland
-      # - Mandible
-      # - Maxilla
-      # - Mouth
-      # - Neck
-      # - Not Applicable
-      # - Pleural Cavity
-      # - Rib Region
-      # - Shoulder
-      # - Skin
-      # - Spleen
-      # - Subcutis
-      # - Tarsus
-      # - Thigh
-      # - Thorax
-      # - Thyroid Gland
-      # - Unknown
-      # - Urethra, Prostate
-      # - Urinary Tract
-      # - Urogenital Tract
     Req: 'Yes'
   cancer_diagnosis_disease_morphology:
     Desc: <The ICD-O-3 code which identifies the specific appearance of cells and tissues (normal and abnormal) used to define the presence and nature of disease.> This list type property accepts multiple values for participants diagnosed with more than one type of cancer, provided that each disease morphology is represented by a valid ICD-O-3 code. In such cases, within the data loading file for the Participant node, the codes for each disease morphology reported as being associated with a single study participant must be separated from one another using the pipe (|) character. <br>CDE ID = 13606049
@@ -973,41 +620,6 @@ PropDefinitions:
     Type:
       value_type: list
       item_type: string
-      # Enum:
-      #   # - Acute Myeloid Leukemia Not Otherwise Specified
-      #   # - Adenocarcinoma of the Gastroesophageal Junction
-      #   # - Colorectal Carcinoma
-      #   # - Invasive Breast Carcinoma
-      #   # - Melanoma 
-      #   # - Non-Small Cell Lung Carcinoma
-      #   # - Ovarian Carcinoma
-      #   # - Plasma Cell Myeloma 
-      #   # - Prostate Carcinoma 
-      #   - Small Cell Lung Carcinoma
-      #   - 8000/0 Benign Neoplasm
-      #   - 8000/1 Neoplasm, Uncertain Whether Benign or Malignant
-      #   - 8000/3 Malignant Neoplasm
-      #   - 8000/6 Metastatic Neoplasm
-      #   - 8000/9 Malignant Neoplasm, Uncertain Whether Primary or Metastatic
-      #   - 8001/0 Benign Cellular Infiltrate
-      #   - 8001/1 Neoplastic Cell
-      #   - 8001/3 Malignant Cell
-      #   - 8003/3 Malignant Giant Cell Neoplasm
-      #   - 8004/3 Malignant Spindle Cell Neoplasm
-      #   - 8005/0 Clear Cell Neoplasm
-      #   - 8005/3 Malignant Ovarian Clear Cell Tumor
-      #   - 8010/2 Carcinoma In Situ
-      #   - 8010/6 Metastatic Carcinoma
-      #   - 8010/9 Carcinomatosis
-      #   - 8012/3 Large Cell Carcinoma
-      #   - 8013/3 Large Cell Neuroendocrine Carcinoma
-      #   - 8014/3 Lung Large Cell Carcinoma with Rhabdoid Phenotype
-      #   - 8015/3 Glassy Cell Carcinoma
-      #   - 8022/3 Pleomorphic Carcinoma
-      #   - 8023/3 NUT Carcinoma
-      #   - 8031/3 Giant Cell Carcinoma
-      #   - 8035/3 Undifferentiated Carcinoma with Osteoclast-Like Giant Cells
-      #   - 8045/3 Combined Small Cell Lung Carcinoma
     Req: 'Yes'
   age_at_enrollment:
     Desc: <The age in days of the subject when the subject enrolled in the study.> The age of the participant as of enrollment, measured in days. <br>CDE ID = 15742605
@@ -1044,7 +656,7 @@ PropDefinitions:
   #   Src: Data Submitter(s)
   #   Type: number
   #   Req: 'Yes'
-  race: # participant prefix to avoid property duplication; will be removed once the study_demographic node is retired out
+  race:
     Desc: <The text for reporting information about race based on the Office of Management and Budget (OMB) categories.> <br>CDE ID = 2192199
     Term:
       - Origin: caDSR - OMB/NCI Standard
@@ -1064,7 +676,7 @@ PropDefinitions:
       - Unknown
       - White
     Req: 'Yes'
-  ethnicity: # participant prefix to avoid property duplication; will be removed once the study_demographic node is retired out
+  ethnicity:
     Desc: <The text for reporting information about ethnicity based on the Office of Management and Budget (OMB) categories.> <br>CDE ID = 2192217
     Term:
       - Origin: caDSR - OMB/NCI Standard
@@ -1079,7 +691,7 @@ PropDefinitions:
       - Not reported
       - Unknown
     Req: 'Yes'
-  sex: # participant prefix to avoid property duplication; will be removed once the study_demographic node is retired out
+  sex:
     Desc: <A textual description of a person's sex at birth.> CDE ID = 7572817
     Term:
       - Origin: caDSR - NCI Standards

--- a/model-desc/popsci-model-props.yml
+++ b/model-desc/popsci-model-props.yml
@@ -64,25 +64,25 @@ PropDefinitions:
   #     item_type: string
   #  Req: 'Yes'  
   # program properties
-  # program_name:
-  #   Desc: <The narrative title used to refer to a broad framework (an administrative umbrella) of goals under which related projects or other research activities are grouped. Example - Clinical Proteomic Tumor Analysis.> <br>CDE ID = 11444542 
-  #   Term:
-  #     - Origin: caDSR - CRDC
-  #       Code: '11444542'
-  #       Value: Program Name Text  
-  #   Src: DSS
-  #   Type: string
-  #   Req: 'Yes'
-  # program_short_name:
-  #   Desc: <An acronym or abbreviated form of the title of a broad framework of goals under which related projects or other research activities are grouped. For example, CPTAC.> <br>CDE ID = 11459801 <br>This property is used as the key via which child records, e.g. project and/or study/trial records, can be associated with the appropriate program during data loading, and to identify the correct records during data updates.
-  #   Term:
-  #     - Origin: caDSR - CRDC
-  #       Code: '11459801'
-  #       Value: Program Short Name Text  
-  #   Src: DSS
-  #   Type: string
-  #   Req: 'Yes'
-  #   Key: true
+  program_name:
+    Desc: <The narrative title used to refer to a broad framework (an administrative umbrella) of goals under which related projects or other research activities are grouped. Example - Clinical Proteomic Tumor Analysis.> <br>CDE ID = 11444542 
+    Term:
+      - Origin: caDSR - CRDC
+        Code: '11444542'
+        Value: Program Name Text  
+    Src: DSS
+    Type: string
+    Req: 'Yes'
+  program_short_name:
+    Desc: <An acronym or abbreviated form of the title of a broad framework of goals under which related projects or other research activities are grouped. For example, CPTAC.> <br>CDE ID = 11459801 <br>This property is used as the key via which child records, e.g. project and/or study/trial records, can be associated with the appropriate program during data loading, and to identify the correct records during data updates.
+    Term:
+      - Origin: caDSR - CRDC
+        Code: '11459801'
+        Value: Program Short Name Text  
+    Src: DSS
+    Type: string
+    Req: 'Yes'
+    Key: true
   # # project properties
   # project_name:
   #   Desc: <The narrative title used to refer to an organ-, site-, disease- or phase-specific data collection within a broad framework of goals under which related studies or other research activities are grouped.> <br>CDE ID = 11459804

--- a/model-desc/popsci-model.yml
+++ b/model-desc/popsci-model.yml
@@ -17,16 +17,16 @@ Nodes:
   #     - property_3
   #     - property_4
   #     - property_5
-  # program:  
-  #   Desc: The Program node contains properties which describe any broad framework and/or administrative umbrella into which inter-related projects, and/or studies/trials and/or other research activities can be grouped, based upon their origins and/or scientific focus. These programs may or may not directly relate to any formal program, e.g. NCI funding programs. Example - Clinical Proteomic Tumor Analysis.
-  #   Tags:
-  #     Category: administrative
-  #     Assignment: core
-  #     Class: primary
-  #     Template: 'Yes'
-  #   Props:
-  #     - program_name #11444542
-  #     - program_short_name #11459801
+  program:  
+    Desc: The Program node contains properties which describe any broad framework and/or administrative umbrella into which inter-related projects, and/or studies/trials and/or other research activities can be grouped, based upon their origins and/or scientific focus. These programs may or may not directly relate to any formal program, e.g. NCI funding programs. Example - Clinical Proteomic Tumor Analysis.
+    Tags:
+      Category: administrative
+      Assignment: core
+      Class: primary
+      Template: 'Yes'
+    Props:
+      - program_name #11444542
+      - program_short_name #11459801
   # project:
   #   Desc: text <WORK NEEDED HERE>
   #   Tags:
@@ -180,12 +180,12 @@ Nodes:
       - data_file_location # CDE ID = 11556141
       - data_file_access_control # NOT CURRENTLY ASSIGNED ANY CDE
 Relationships:
-  # belongs_to:
-  #   Mul: many_to_one
-  #   Ends:
-      # - Src: study # so can a lowest-level study belong directly to a highest-level program?
-      #   Dst: program   
-  #   Props: null
+  belongs_to:
+    Mul: many_to_one
+    Ends:
+      - Src: study # so can a lowest-level study belong directly to a highest-level program?
+        Dst: program   
+    Props: null
   associated_with: # group all file relationships in here?
     Mul: many_to_one
     Ends:

--- a/model-desc/popsci-model.yml
+++ b/model-desc/popsci-model.yml
@@ -138,7 +138,7 @@ Nodes:
       Template: 'Yes'
     Props:
       - participant_id # per CTDC, CDE ID = 12220014
-      - participant_case_indicator # CDE ID = 14883047 as noted here 12-05-25
+      - participant_case_indicator # NOT CURRENTLY ASSIGNED ANY CDE
       - cancer_diagnosis_primary_site # CDE ID = 14883047 as noted here 12-05-25
       - cancer_diagnosis_disease_morphology # CDE ID = 13606049 as noted here 12-05-25
       - age_at_enrollment # per CTDC, CDE = 12299548

--- a/model-desc/popsci-model.yml
+++ b/model-desc/popsci-model.yml
@@ -1,7 +1,8 @@
 # Population Sciences DC data model nodes, properties and relationships file
 # Title case names are "reserved" (meaningful to the parser)
 # Lower case names are labels for the entities
-
+Handle: PSDC
+Version: v1.0.0
 Nodes:
   # node:
   #   Desc: text
@@ -47,19 +48,17 @@ Nodes:
       - study_name # CDE ID = 11459810
       - study_short_name # CDE ID = 11459812
       - study_id # CDE ID = 5054234
-      - dbgap_accession_id
+      - dbgap_accession_id # NOT CURRENTLY ASSIGNED ANY CDE
       - study_description # CDE ID = 3444002
-      #- study_type # CDE ID = 11160683
-      - study_design
-      - study_status
-      - enrollment_beginning_year
-      - enrollment_ending_year
-      - study_beginning_year
-      - study_ending_year
-      #- number_of_participants
-      - biospecimen_collection
+      - study_design # NOT CURRENTLY ASSIGNED ANY CDE
+      - study_status # NOT CURRENTLY ASSIGNED ANY CDE
+      - enrollment_beginning_year # NOT CURRENTLY ASSIGNED ANY CDE
+      - enrollment_ending_year # NOT CURRENTLY ASSIGNED ANY CDE
+      - study_beginning_year # NOT CURRENTLY ASSIGNED ANY CDE
+      - study_ending_year # NOT CURRENTLY ASSIGNED ANY CDE
+      - biospecimen_collection # NOT CURRENTLY ASSIGNED ANY CDE
   study_personnel:
-    Desc: The Study Personnel node contains properties which identify the individuals most directly involved in the conduct of any given study and/or the analysis of the data generatedy, and which indicate the specific role(s) of each member of the study team.
+    Desc: The Study Personnel node contains properties which identify the individuals most directly involved in the conduct of any given study and/or the analysis of the data generated, and which indicate the specific role(s) of each member of the study team.
     Tags:
       Category: study
       Assignment: core
@@ -70,9 +69,7 @@ Nodes:
       - person_first_name # CDE ID = 2179589
       - person_last_name # CDE ID = 2179591
       - person_middle_name # CDE ID = 2179590
-      #- person_orcid_id # CDE ID = 10624734
-      - person_institution
-      #- person_email_address
+      - person_institution # NOT CURRENTLY ASSIGNED ANY CDE
       - person_role # CDE ID = 2201713
   associated_link:
     Desc: The Associated Link node contains the properties required to associate multiple links to additional information about any given study with the appropriate study record, and to define an inuitive label via which each link will be diplayed within the UI. 
@@ -82,9 +79,9 @@ Nodes:
       Class: secondary
       Template: 'Yes'
     Props:
-      - associated_link_record_id #CDE ID = 14822135
-      - associated_link_name #CDE ID = 14822136
-      - associated_link_url #CDE ID = 14822140
+      - associated_link_record_id # CDE ID = 14822135
+      - associated_link_name # CDE ID = 14822136
+      - associated_link_url # CDE ID = 14822140
   publication:
     Desc: The Publication node is comprised of properties which describe publications that are directly associated with any given study of interest, inclusive of the location(s) at which publications can be viewed in electronic form.
     Tags:
@@ -94,12 +91,12 @@ Nodes:
       Template: 'Yes'
     Props:
       - publication_record_id # CDE ID = 14822135
-      - publication_title
-      - authorship
-      - year_of_publication
-      - journal_citation
-      - digital_object_id
-      - pubmed_id
+      - publication_title # NOT CURRENTLY ASSIGNED ANY CDE
+      - authorship # NOT CURRENTLY ASSIGNED ANY CDE
+      - year_of_publication # NOT CURRENTLY ASSIGNED ANY CDE
+      - journal_citation # NOT CURRENTLY ASSIGNED ANY CDE
+      - digital_object_id # NOT CURRENTLY ASSIGNED ANY CDE
+      - pubmed_id # NOT CURRENTLY ASSIGNED ANY CDE
   study_country:
     Desc: The Study Country node contains only a single property via which potentially lengthy lists of countires from which study participants were included can be associated with the study in question, using data loading files of minimal complexity.
     Tags:
@@ -109,7 +106,7 @@ Nodes:
       Template: 'Yes'
     Props:
       - study_country_record_id # CDE ID = 14822135
-      - study_country
+      - study_country # NOT CURRENTLY ASSIGNED ANY CDE
   study_state_province_territory:
     Desc: The Study State/Province/Territory node contains only a single proerty via which potentially lengthy lists of states and/or provinces and/or territories from which study participants were included can be associated with the study in question, using data loading files of minimal complexity.
     Tags:
@@ -119,45 +116,7 @@ Nodes:
       Template: 'Yes'
     Props:
       - study_state_record_id # CDE ID = 14822135
-      - study_state_province_territory
-  # study_demographic:
-  #   Desc: The Demographic node is comprised of properties which describe the key demographic characteristics of the study population as whole, such as the sexes, genders, races and etnnicities represented.
-  #   Tags:
-  #     Category: study
-  #     Assignment: core
-  #     Class: primary
-  #     Template: 'Yes'
-  #   Props:
-  #     - study_demographic_record_id #14822135
-  #     - study_participant_minimum_age
-  #     - study_participant_maximum_age
-  #     - study_participant_median_age
-  #     - race # use list type property?
-  #     - ethnicity # use list type property?
-  #     - sex # use list type property? Or use definite, exclusive values like Female Only, Mixed?
-  #     - gender #10748236 # use list type property?
-  #     - ncbi_taxonomy_id #10543100
-  #     - ncbi_taxonomy_name #10543082
-  # primary_diagnosis:
-  #   Desc: The Diagnosis node contains only a single property which captures the various and potentially numerous primary diseases with which study participants were diagnosed.
-  #   Tags:
-  #     Category: study
-  #     Assignment: core
-  #     Class: primary
-  #     Template: 'Yes'
-  #   Props:
-  #     - primary_diagnosis_record_id #14822135
-  #     - primary_diagnosis_disease_term
-  # comorbidity:
-  #   Desc: The Comorbidity node contains only a single property which captures any comorbidities being examined by the study in question as potential contributing factors.
-  #   Tags:
-  #     Category: study
-  #     Assignment: core
-  #     Class: primary
-  #     Template: 'Yes'
-  #   Props:  
-  #     - comorbidity_record_id #14822135
-  #     - comorbidity_disease_term
+      - study_state_province_territory # NOT CURRENTLY ASSIGNED ANY CDE
   data_collection:
     Desc: The Data Collection node is comprised of the properties required to describe the nature of the data being gathered by any given study, and to define the extent to which each data collection category was covered.
     Tags:
@@ -166,12 +125,10 @@ Nodes:
       Class: primary
       Template: 'Yes'
     Props:  
-      - data_collection_record_id #14822135
-      #- data_collection_grouping # the higher-level grouping or family to which each specific data collection category belongs
-      - data_collection_category # for example Mental Health Assessments, Cardiovascular Health Assessments, Smoking History, etc., all per CV
-      #- data_collection_category_annotation_coverage # for example Extensive, Typical, Limited, Minimal
-      - data_collection_category_annotation_count # the number of annotations per data collection category
-      #- data_collection_category_assessed
+      - data_collection_record_id # CDE ID = 14822135
+      - data_collection_category # for example Mental Health Assessments, Cardiovascular Health Assessments, Smoking History, etc., all per CV # NOT CURRENTLY ASSIGNED ANY CDE
+      - data_collection_category_annotation_count # the number of annotations per data collection category # NOT CURRENTLY ASSIGNED ANY CDE but property will ultimately be deprecated, and superseded by data_collection_category_assessed as noted below
+      #- data_collection_category_assessed  # NOT CURRENTLY ASSIGNED ANY CDE and this property will supersede the current data_collection_category_annotation_count as noted above
   participant:
     Desc: The Particpant node is comprised of the properties which define and characterize each study participant
     Tags:
@@ -181,26 +138,26 @@ Nodes:
       Template: 'Yes'
     Props:
       - participant_id # per CTDC, CDE ID = 12220014
-      - participant_case_indicator
-      - cancer_diagnosis_primary_site
-      - cancer_diagnosis_disease_morphology
+      - participant_case_indicator # CDE ID = 14883047 as noted here 12-05-25
+      - cancer_diagnosis_primary_site # CDE ID = 14883047 as noted here 12-05-25
+      - cancer_diagnosis_disease_morphology # CDE ID = 13606049 as noted here 12-05-25
       - age_at_enrollment # per CTDC, CDE = 12299548
-      - age_at_first_cancer_diagnosis
-      #- year_of_birth
+      - age_at_first_cancer_diagnosis # NOT CURRENTLY ASSIGNED ANY CDE
+      #- year_of_birth # NOT CURRENTLY ASSIGNED ANY CDE
       - race # per CTDC, CDE ID = 2192199
       - ethnicity # per CTDC, CDE ID = 2192217
       - sex # per CTDC, CDE ID = 7572817)
       #- height # per CTDC, CDE ID = 2179643
       #- weight # per CTDC, CDE ID = 2179689
       #- body_surface_area # per CTDC, CDE ID = 653
-      #- body_mass_index
+      #- body_mass_index # NOT CURRENTLY ASSIGNED ANY CDE
       #- occupation # per CTDC, CDE ID = 6617540
       #- income # per CTDC, CDE ID = 14834966
       #- highest_level_of_education # per CTDC, CDE ID = 2681552
-      #- tobacco_usage
-      #- alcohol_consumption
-      #- country_of_residence
-      #- state_province_territory_of_residence
+      #- tobacco_usage # NOT CURRENTLY ASSIGNED ANY CDE
+      #- alcohol_consumption # NOT CURRENTLY ASSIGNED ANY CDE
+      #- country_of_residence # NOT CURRENTLY ASSIGNED ANY CDE
+      #- state_province_territory_of_residence # NOT CURRENTLY ASSIGNED ANY CDE
       - ncbi_taxonomy_id # per DSS for CTDC, CDE ID = 10543100
       #- participant_ncbi_taxonomy_name # per DSS for CTDC, CDE ID = 10543082
   file:
@@ -221,39 +178,23 @@ Nodes:
       - data_file_compression_status # CDE ID = 11387114
       - data_file_uuid # CDE ID = 14826100
       - data_file_location # CDE ID = 11556141
-      #- data_file_signed_url # to be used ONLY in support of the MVP-style direct file download, and to be removed outright post-MVP
-      - data_file_access_control
+      - data_file_access_control # NOT CURRENTLY ASSIGNED ANY CDE
 Relationships:
   # belongs_to:
   #   Mul: many_to_one
   #   Ends:
-      # - Src: study
-      #   Dst: project
       # - Src: study # so can a lowest-level study belong directly to a highest-level program?
-      #   Dst: program
-      #- Src: project # this relationship can be removed because project is above study?
-        #Dst: study
-    #   - Src: project # this seems legitimate
-    #     Dst: program     
-    # Props: null
+      #   Dst: program   
+  #   Props: null
   associated_with: # group all file relationships in here?
     Mul: many_to_one
     Ends:
       - Src: file
         Dst: study
-      # - Src: data_file
-      #   Dst: project
       - Src: participant
         Dst: study
       - Src: data_collection
         Dst: study
-      # - Src: comorbidity
-      #   Dst: study
-      # - Src: primary_diagnosis
-      #   Dst: study
-      # - Src: study_demographic
-      #   Dst: study
-      #   Mul: one_to_one
       - Src: study_state_province_territory
         Dst: study
       - Src: study_country


### PR DESCRIPTION
Added version number of v1.0.0

Removed the vast majority of the numerous properties, property definitions, temporary controlled vocabularies, etc. which had already commented out, and which are simply no longer relevant to the application in its MVP+ form