### PR TITLE
MVM v1.0.0 for MVP+ release

### DIFF
--- a/model-desc/popsci-model-props.yml
+++ b/model-desc/popsci-model-props.yml
@@ -62,7 +62,18 @@ PropDefinitions:
   #   Type:
   #     value_type: list
   #     item_type: string
-  #  Req: 'Yes'  
+  #  Req: 'Yes'
+
+  #  Syntax for full CDE rerefrence
+  #  Term:
+  #     - Origin: caDSR
+  #       Code: '11459801'
+  #       Value: 'Program Short Name Text'
+  #       Version: '1'
+  #       Tags:
+  #         Provenance: DSS
+  #         Added: 12-23-25
+  #         Labeled: Program 
   # program properties
   program_name:
     Desc: <The narrative title used to refer to a broad framework (an administrative umbrella) of goals under which related projects or other research activities are grouped. Example - Clinical Proteomic Tumor Analysis.> <br>CDE ID = 11444542 
@@ -107,65 +118,79 @@ PropDefinitions:
   study_name: 
     Desc: <The narrative title used as a textual label for a research data collection.> <br>CDE ID = 11459810
     Term:
-      - Origin: caDSR - CRDC
+      - Origin: caDSR
         Code: '11459810'
-        Value: Study Name Text  
+        Value: Study Administration Study Name Text # Study Name Text
+        Version: '4'
+        Tags:
+          Provenance: CRDC
+          Labeled: Study Name
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
-    Tags:
-      Labeled: Study Name
   study_short_name:
     Desc:  <The acronym or abbreviated form of the title for a research data collection.> <br>CDE ID = 11459812 <br>This property is used as the key via which child records, e.g. publication records and study demographic records, can be associated with the appropriate study during data loading, and to identify the correct records during data updates.
     Term:
-      - Origin: caDSR - CRDC
+      - Origin: caDSR
         Code: '11459812'
-        Value: Study Short Name Text
+        Value: Study Administration Study Short Name Text # Study Short Name Text
+        Version: '4'
+        Tags:
+          Provenance: CRDC
+          Labeled: Study Acronym
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
     Key: true
-    Tags:
-      Labeled: Study Acronym
   study_id:
     Desc: <A unique identifier assigned to a clinical study.> Any external identifier(s) by which the study in question is already known. <br>CDE ID = 5054234
     Term:
-      - Origin: caDSR - NMDP
-        Code: '5054234'
-        Value: Clinical Study Identifier  
+      - Origin: caDSR
+        Code: '16979764'
+        Value: Study Administration Study Identifier
+        Version: '1'
+        Tags:
+          Provenance: CRDC/PSDC
+          Labeled: Study ID 
     Src: Data Submitter(s)
     Type: string
     Req: 'No'
-    Tags:
-      Labeled: Study ID 
   dbgap_accession_id:
-    Desc: The dbGaP-assigned identifier by which the study in question is known. <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: The dbGaP-assigned identifier by which the study in question is known. <br>CDE ID = 11524544
     Term:
       - Origin: caDSR
-        Code: 'code/ID'
-        Value: Data Element Name  
+        Code: '11524544'
+        Value: Research Activity dbGaP Accession Number Identifier
+        Version: '1'
+        Tags:
+          Provenance: CRDC
+          Labeled: dbGaP ID
     Src: Data Submitter(s)
     Type: string
     Req: 'No'
-    Tags:
-      Labeled: dbGaP ID 
   study_description: 
-    Desc: <A textual description of the study, with components such as objectives or goals.> A narrative description of the study outlining its design, conduct and data collection goals. <br>CDE ID = 3444002
+    Desc: <A textual description of the study, with components such as objectives or goals.> A narrative description of the study outlining its design, conduct and data collection goals. <br>CDE ID = 16188024
     Term:
-      - Origin: caDSR - CCDI
-        Code: '3444002'
-        Value: Study Research Identification Descriptive Text   
+      - Origin: caDSR - Ped/CCDI
+        Code: '16188024'
+        Value: Research Activity Study Description Text
+        Version: '1'
+        Tags:
+          Provenance: Ped/CCDI
+          Labeled: Description
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
-    Tags:
-      Labeled: Description
   study_design: 
-    Desc: Text here <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: Text here <br>CDE ID = 16979765
     Term:
-      - Origin: caDSR - CRDC
-        Code: 'code/ID'
-        Value: Data Element Name 
+      - Origin: caDSR
+        Code: '16979765'
+        Value: Research Activity Study Design Type
+        Version: '1'
+        Tags:
+          Provenance:  CRDC/PSDC
+          Labeled: Study Design
     Src: Data Submitter(s)
     Enum: # Acceptable values listed below are the actual values propsed by the working group
       - Case Series Study # Cases are not compared to subjects without the manifestations of interest; Case Series studies are primarily descriptive reports observed in groups under study.
@@ -182,73 +207,94 @@ PropDefinitions:
       - Methods Development Study
       - Other
     Req: 'Yes'
-    Tags:
-      Labeled: Study Design
   study_status: 
-    Desc: An indicator as to the status of the study as of its submission. <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: An indicator as to the status of the study as of its submission. <br>CDE ID = 15607838
     Term:
-      - Origin: caDSR - CRDC
-        Code: 'code/ID'
-        Value: Data Element Name 
+      - Origin: caDSR
+        Code: '15607838'
+        Value: Study Administration Study Status
+        Version: '1'
+        Tags:
+          Provenance: Ped/CRDC
+          Labeled: Status
     Src: Data Submitter(s)
     Enum: # Acceptable values listed here are the actual values propsed by the working group
       - Active # Data collection still in progress
       - Closed # Data collection completed, data analysis in progress
     Req: Preferred
-    Tags:
-      Labeled: Status 
   enrollment_beginning_year:
-    Desc: The year in which the study began enrolling participants. <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: The year in which the study began enrolling participants. <br>CDE ID = 16979766
     Term:
       - Origin: caDSR
-        Code: 'code/ID'
-        Value: Data Element Name  
+        Code: '16979766'
+        Value: Research Activity Study Enrollment Start Year Date
+        Version: '1'
+        Tags:
+          Provenance: CRDC/PSDC
     Src: Data Submitter(s)
     Type: integer
     Req: 'Yes'
   enrollment_ending_year:
-    Desc: The year in which the study stopped enrolling participants. <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: The year in which the study stopped enrolling participants. <br>CDE ID = 16979767
     Term:
       - Origin: caDSR
-        Code: 'code/ID'
-        Value: Data Element Name  
+        Code: '16979767'
+        Value: Research Activity Study Enrollment End Year Date
+        Version: '1'
+        Tags:
+          Provenance: CRDC/PSDC
     Src: Data Submitter(s)
     Type: integer
     Req: 'Yes'
   study_beginning_year:
-    Desc: The year in which the study was initiated. <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: The year in which the study was initiated. <br>CDE ID = 15607845
     Term:
       - Origin: caDSR
-        Code: 'code/ID'
-        Value: Data Element Name  
+        Code: '15607845'
+        Value: Study Administration Study Start Year Date
+        Version: '1'
+        Tags:
+          Provenance: Ped/CCDI
     Src: Data Submitter(s)
     Type: integer
     Req: 'Yes'
   study_ending_year:
-    Desc: The year in which the study was completed. <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: The year in which the study was completed. <br>CDE ID = 15607913
     Term:
       - Origin: caDSR
-        Code: 'code/ID'
-        Value: Data Element Name  
+        Code: '15607913'
+        Value: Study Administration Study End Year Date
+        Version: '1'
+        Tags:
+          Provenance: Ped/CCDI
     Src: Data Submitter(s)c
     Type: string # this accomodates use of the the term Ongoing for studies that are still active
     Req: 'Yes'
   biospecimen_collection:
-    Desc: A Boolean indication as to whether the study in question included the collection of biospecimens from any of the participants enrolled in the study, that gives no indication as to the type and/or number of any such biospecimens. <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: A Boolean indication as to whether the study in question included the collection of biospecimens from any of the participants enrolled in the study, that gives no indication as to the type and/or number of any such biospecimens. <br>CDE ID = 16979768
+    Term:
+      - Origin: caDSR
+        Code: '16979768'
+        Value: Research Activity Biospecimen Collection Indicator
+        Version: '1'
+        Tags:
+          Provenance: CRDC/PSDC
+          Labeled: Biospecimen Collection, Biospecimens
     Src: Data Submitter(s)
     Enum: 
       - 'Yes'
       - 'No'
     Req: Preferred
-    Tags:
-      Labeled: Biospecimen Collection, Biospecimens
   # study_personnel properties
   study_personnel_record_id:  
     Desc: <A unique sequence of characters used to identify a linkage between related records.> A unique identifier of each each study personnel record associated with the study in question, used to identify the appropriate study personnel record(s) during data loading and/or record modification. The value of this record ID also dictates the order in which study personnel are listed within the application's UI. <br>CDE ID = 14822135
     Term:
-      - Origin: caDSR - CTDC
+      - Origin: caDSR
         Code: '14822135'
         Value: Data Record Link Unique Identifier
+        Version: '1'
+        Tags:
+          Provenance: CTDC
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
@@ -256,53 +302,65 @@ PropDefinitions:
   person_first_name:
     Desc: <A word or group of words indicating a person's first (personal or given) name; the name that precedes the surname. Synonym = Given Name.> The first or given name of each individual who is responsible for or directly involved in the conduct and/or analysis of the clinical trial or research project. <br>CDE ID = 2179589
     Term:
-      - Origin: CSAERS/NCI Standard
+      - Origin: caDSR
         Code: '2179589'
         Value: Person Given/First Name
+        Version: '2'
+        Tags:
+          Provenance: NCI Standard
+          Labeled: Full Name
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
-    Tags:
-      Labeled: Full Name
   person_last_name:
     Desc: <A means of identifying an individual by using a word or group of words indicating a person's last (family) name. Synonym = Last Name, Surname.> The last or family name of each individual responsible for or directly involved in the conduct and/or analysis of the clinical trial or research project. <br>CDE ID = 2179591
     Term:
-      - Origin: CSAERS/NCI Standard
+      - Origin: caDSR
         Code: '2179591'
         Value: Person Family/Last Name
+        Version: '2'
+        Tags:
+          Provenance: NCI Standard
+          Labeled: Full Name
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
-    Tags:
-      Labeled: Full Name
   person_middle_name:
     Desc: <A means of identifying an individual by using a word or group of words indicating a person's middle name.> The middle name of each individual responsible for or directly involved in the conduct and/or analysis of the clinical trial or research project. <br>CDE ID = 2179590
     Term:
-      - Origin: CSAERS/NCI Standard
+      - Origin: caDSR
         Code: '2179590'
-        Value: Person Middle Name 
+        Value: Person Middle Name
+        Version: '2'
+        Tags:
+          Provenance: NCI Standard
+          Labeled: Full Name
     Src: Data Submitter(s)
     Type: string
-    Req: 'No'
-    Tags:
-      Labeled: Full Name
+    Req: 'No' 
   person_institution:
-    Desc: text here <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: text here <br>CDE ID = 16990046
     Term:
       - Origin: caDSR
-        Code: 'code/ID'
-        Value: Data Element Name
+        Code: '16990046'
+        Value: Person Study Personnel Institution Name
+        Version: '1'
+        Tags:
+          Provenance: CRDC/PSDC
+          Labeled: Institution
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
-    Tags:
-      Labeled: Institution
   person_role:
     Desc: <The text that describes the distinguishable characteristics of the action or activity assigned to or required or expected of a person in a formal association with a group or organization.> An indicator as to the role(s) and/or responsibilities of each individual responsible for or directly involved in the conduct and/or analysis of the clinical trial or research project. Each such individual must have at least one specified role, but any given indivdual may be assigned multiple roles for the study in question. Within the data loading file, multiple roles assigned to a single individual must be separated from one another using the pipe (|) character. <br>CDE ID = 2201713
     Term:
-      - Origin: caDSR - NCI Standard
+      - Origin: caDSR 
         Code: '2201713'
-        Value: Person Affiliation Role Text Type 
+        Value: Person Affiliation Role Text Type
+        Version: '2'
+        Tags:
+          Provenance: NCI Standard
+          Labeled: Position or Role
     Src: Data Submitter(s)
     Type:
       value_type: list
@@ -330,15 +388,16 @@ PropDefinitions:
         - Study Chairperson
         - Study Coordinator
     Req: 'Yes'  
-    Tags:
-      Labeled: Position or Role
   # associated_link properties
   associated_link_record_id:  
     Desc: <A unique sequence of characters used to identify a linkage between related records.> A unique identifier of each associated link record, used to identify the appropriate associated link record(s) during data loading and/or record modification. The value of this record ID also dictates the order in which associated links are listed within the application's UI.<br>CDE ID = 14822135
     Term:
-      - Origin: caDSR - CTDC
+      - Origin: caDSR
         Code: '14822135'
         Value: Data Record Link Unique Identifier
+        Version: '1'
+        Tags:
+          Provenance: CRDC/CTDC
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
@@ -365,113 +424,170 @@ PropDefinitions:
   publication_record_id:
     Desc: <A unique sequence of characters used to identify a linkage between related records.> A unique identifier of each publication record associated with the study in question, used to identify the appropriate publication record(s) during data loading and/or record modification. The value of this record ID also dictates the order in which publications are listed within the application's UI. <br>CDE ID = 14822135
     Term:
-      - Origin: caDSR - CTDC
+      - Origin: caDSR
         Code: '14822135'
         Value: Data Record Link Unique Identifier
+        Version: '1'
+        Tags:
+          Provenance: CRDC/CTDC
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
     Key: true
   publication_title:
-    Desc: The full title of the publication stated exactly as it appears on the published work. <br>This property is used as the key via which to identify the correct records during data updates. <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: The full title of the publication stated exactly as it appears on the published work. <br>CDE ID = 16078531
+    Term: 
+      - Origin: caDSR
+        Code: '16078531'
+        Value: Study Administration Publication Identification Title Text
+        Version: '1'
+        Tags:
+          Provenance: CRDC/CTDC
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
   authorship:
-    Desc: A list of authors for the cited work. More specifically, for publications with no more than three authors, authorship quoted in full; for publications with more than three authors, authorship abbreviated to first author et al. <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: A list of authors for the cited work. More specifically, for publications with no more than three authors, authorship quoted in full; for publications with more than three authors, authorship abbreviated to first author et al. <br>CDE ID = 16081468
+    Term:
+      - Origin: caDSR
+        Code: '16081468'
+        Value: Study Administration Publication Identification Citation Author List Text
+        Version: '1'
+        Tags:
+          Provenance: CRDC/CTDC
+          Labeled: Authorship
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
-    Tags:
-       Labeled: Authorship
   year_of_publication:
-    Desc: The year in which the cited work was published. <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: The year in which the cited work was published. <br>CDE ID = 16081475
+    Term:
+      - Origin: caDSR
+        Code: '16081475'
+        Value: Study Administration Publication Identification Year Date
+        Version: '1'
+        Tags:
+          Provenance: CRDC/CTDC
+          Labeled: Year of Publication
     Src: Data Submitter(s)
     Type: integer
     Req: 'Yes'
-    Tags:
-       Labeled: Year of Publication
   journal_citation:
-    Desc: The name of the journal in which the cited work was published, inclusive of the citation itself in terms of journal volume number, part number where applicable, and page numbers. <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: The name of the journal in which the cited work was published, inclusive of the citation itself in terms of journal volume number, part number where applicable, and page numbers. <br>CDE ID = 16081476
+    Term:
+      - Origin: caDSR
+        Code: '16081476'
+        Value: Study Administration Publication Identification Journal Citation Text
+        Version: '1'
+        Tags:
+          Provenance: CRDC/CTDC
+          Labeled: Journal
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
-    Tags:
-       Labeled: Journal
   digital_object_id:
-    Desc: Where applicable, the digital object identifier for the cited work, by which it can be permanently identified, and linked to via the internet. <br>Values of this property must contain only the alphanumeric string of the digital object identifier itself, exclusive of any prefix such as "DOI:", such that values can be correctly interpreted and displayed as hyperlinks within the application. <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: Where applicable, the digital object identifier for the cited work, by which it can be permanently identified, and linked to via the internet. <br>Values of this property must contain only the alphanumeric string of the digital object identifier itself, exclusive of any prefix such as "DOI:", such that values can be correctly interpreted and displayed as hyperlinks within the application. <br>CDE ID = 15915370
+    Term: 
+      - Origin: caDSR
+        Code: '15915370'
+        Value: Study Administration Publication Identification DOI Text
+        Version: '1'
+        Tags:
+          Provenance: Ped/CCDI
+          Labeled: DOI
     Src: Data Submitter(s)
     Type: string
     Req: Preferred
-    Tags:
-       Labeled: DOI
   pubmed_id:
-    Desc: Where applicable, the unique numerical identifier assigned to the cited work by PubMed, by which it can be linked to via the internet. <br>Values of this property must contain only the numeric string of the PubMed ID itself, exclusive of any prefix such as "PMID:", such that values can be correctly interpreted and displayed as hyperlinks within the application. <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: Where applicable, the unique numerical identifier assigned to the cited work by PubMed, by which it can be linked to via the internet. <br>Values of this property must contain only the numeric string of the PubMed ID itself, exclusive of any prefix such as "PMID:", such that values can be correctly interpreted and displayed as hyperlinks within the application. <br> CDE ID = 15915377
+    Term:
+      - Origin: caDSR
+        Code: '15915377'
+        Value: Study Administration Publication Identification PubMed ID Text
+        Version: '1'
+        Tags:
+          Provenance: Ped/CCDI
+          Labeled: PubMed ID
     Src: Data Submitter(s)
     Type: number
     Req: Preferred
-    Tags:
-       Labeled: PubMed ID
-  # study_country properties
+  # study_country properties    Tags completed through here as of 2.30pm 03-03-26
   study_country_record_id:
     Desc: <A unique sequence of characters used to identify a linkage between related records.> A unique identifier of each country record associated with the study in question, used to identify the appropriate country record(s) during data loading and/or record modification. <br>CDE ID = 14822135
     Term:
-      - Origin: caDSR - CTDC
+      - Origin: caDSR
         Code: '14822135'
-        Value: Data Record Link Unique Identifier 
+        Value: Data Record Link Unique Identifier
+        Version: '1'
+        Tags:
+          Provenance: CRDC/CTDC
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
     Key: true
   study_country:
-    Desc: text here <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: text here <br>CDE ID = 16990793
     Term:
       - Origin: caDSR
-        Code: 'code/ID'
-        Value: Data Element Name  
+        Code: '16990793'
+        Value: Research Activity Study Country Name
+        Version: '1'
+        Tags:
+          Provenance: CRDC/PSDC
+          Labeled: Countries
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
-    Tags:
-      Labeled: Countries
   # study_state_province_territory properties
   study_state_record_id:
     Desc: <A unique sequence of characters used to identify a linkage between related records.> A unique identifier of each state, province or territory associated with the study in question, used to identify the appropriate state, province or territory record(s) during data loading and/or record modification. <br>CDE ID = 14822135
     Term:
-      - Origin: caDSR - CTDC
+      - Origin: caDSR
         Code: '14822135'
         Value: Data Record Link Unique Identifier
+        Version: '1'
+        Tags:
+          Provenance: CRDC/CTDC
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
     Key: true
   study_state_province_territory:
-    Desc: text here <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: text here <br>CDE ID = 16990818
     Term:
       - Origin: caDSR
-        Code: 'code/ID'
-        Value: Data Element Name  
+        Code: '16990818'
+        Value: Research Activity Study State Province Territory Name
+        Version: '1'
+        Tags:
+          Provenance: CRDC/PSDC
+          Labeled: States, Provinces and Territories
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
-    Tags:
-      Labeled: States, Provinces and Territories
   data_collection_record_id:
     Desc: <A unique sequence of characters used to identify a linkage between related records.> A unique identifier of each data collection record associated with the study in question, used to identify the appropriate data collection record(s) during data loading and/or record modification. <br>CDE ID = 14822135
     Term:
-      - Origin: caDSR - CTDC
+      - Origin: caDSR
         Code: '14822135'
         Value: Data Record Link Unique Identifier
+        Version: '1'
+        Tags:
+          Provenance: CRDC/CTDC
     Src: PSc
     Type: string
     Req: 'Yes'
     Key: true
   data_collection_category:
-    Desc: text here <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: text here <br>CDE ID = 16990979
     Term:
       - Origin: caDSR
-        Code: 'code/ID'
-        Value: Data Element Name 
+        Code: '16990979'
+        Value: Research Activity Data Collection Category text
+        Version: '1'
+        Tags:
+          Provenance: CRDC/PSDC
+          Labeled: Data Collection Categories
     Src: PSc
     Enum: # n=71
       - Age # Demographics / Lifestyle / Life events / Quality of life
@@ -546,27 +662,28 @@ PropDefinitions:
       - Injury, Poisoning, Certain Other Consequences of External Causes
       - Vital Status
     Req: 'Yes'
-    Tags:
-      Labeled: Data Collection Categories
   data_collection_category_annotation_count: # subject to confirmation from the working group, this property will morph into a binary Yes versus No indicator as to whether the data collection category in question was examined or not, given that the reporting of the number of variables per data collection category will be too burdensome
-    Desc: Pending additional data model and application code changes, this property functions as a binary indicator as to whether variables associated with any given data collection were assessed or not. A value of 0 should be used to indicate that no variables associated with a given data collection category were assessed. Whereas regradless of how many variables within a data collection category were assessed, a value of 1 should be used simply to indicate that variables associated with a given data collection category were indeed assessed. <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: Pending additional data model and application code changes, this property functions as a binary indicator as to whether variables associated with any given data collection were assessed or not. A value of 0 should be used to indicate that no variables associated with a given data collection category were assessed. Whereas regradless of how many variables within a data collection category were assessed, a value of 1 should be used simply to indicate that variables associated with a given data collection category were indeed assessed. <br>CDE ID = 16991477
     Term:
       - Origin: caDSR
-        Code: 'code/ID'
-        Value: Data Element Name 
+        Code: '16991477'
+        Value: Research Activity Data Collection Category Annotation Count
+        Version: '1'
+        Tags:
+          Provenance: CRDC/PSDC
+          Labeled: Assessed
     Src: FNL
     Enum:
       - "0"
       - "1"
     Req: 'Yes'
-    Tags:
-      Labeled: Assessed
   # data_collection_category_assessed: # per working group discussions, this property now replaces the data_collection_annotation_count property, providing a simple Yes versus No indicator as to whether the data collection category in question was examined or not
-  #   Desc: text here <br>NOT CURRENTLY ASSIGNED ANY CDE
+  #   Desc: text here <br>CDE ID = 16991478
   #   Term:
   #     - Origin: caDSR
-  #       Code: 'code/ID'
-  #       Value: Data Element Name 
+  #       Code: '16991478'
+  #       Value: Research Activity Data Collection Category Assessed Count
+  #       Version: '1'
   #   Src: FNL
   #   Enum:
   #     - 'Yes'
@@ -578,32 +695,39 @@ PropDefinitions:
   participant_id:
     Desc: <A sequence of letters, numbers, or characters that uniquely identifies the participant who has taken part in the investigation or research study.> The globally unique ID by which any given participant can be unambiguously identified and displayed across studies/trials. <br>CDE ID = 12220014 <br>This property is used to identify the correct records during data updates.
     Term:
-      - Origin: caDSR - CDS
+      - Origin: caDSR
         Code: '12220014'
         Value: Subject Data Origin Identifier
         Version: '1'
+        Tags:
+          Provenance: CRDC/GC
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
     Key: true
   participant_case_indicator:
-    Desc: <A response to indicate whether or not the participant is a case in the study in question.> <br>CDE ID = 14883047
+    Desc: <A response to indicate whether or not the participant is a case in the study in question.> <br>CDE ID = 16991485
     Term:
-      - Origin: x
-        Code: 'y' # TBD as of 12-09-25
-        Value: Subject Participant Case Indicator
-        Version: '1' # ?    
+      - Origin: caDSR
+        Code: '16991485'
+        Value: Research Activity Study Participant Indicator
+        Version: '1'
+        Tags:
+          Provenance: CRDC/PSDC  
     Src: Data Submitter(s)
     Enum:
       - 'No'
       - 'Yes'
   cancer_diagnosis_primary_site:
-    Desc: <The location within the body from where the disease of interest originated as captured in the Uberon identifier.> More specifically, primary disease sites must be reported in the form of the appripriate Uberon codes.This list type property accepts multiple values for participants diagnosed with more than one type of cancer, provided that each primary disease site is specified by a valid Uberon code. In such cases, within the data loading file for the Participant node, the codes for each primary disease site reported asd being assocaited with a single study participant must be separated from one another using the pipe (|) character.  <br>CDE = 14883047
+    Desc: <The location within the body from where the disease of interest originated as captured in the Uberon identifier.> More specifically, primary disease sites must be reported in the form of the appripriate Uberon codes. This list type property accepts multiple values for participants diagnosed with more than one type of cancer, provided that each primary disease site is specified by a valid Uberon code. In such cases, within the data loading file for the Participant node, the codes for each primary disease site reported asd being assocaited with a single study participant must be separated from one another using the pipe (|) character.  <br>CDE = 14883047
     Term:
-      - Origin: TBD
+      - Origin: caDSR
         Code: '14883047'
         Value: Primary Disease Anatomic Site UBERON Identifier
-        Version: '1' # ?    
+        Version: '1'
+        Tags:
+          Provenance: CRDC Standard
+          Labeled: Cancer Type by Uberon Primary Disease Site
     Src: Data Submitter(s)
     Type:
       value_type: list
@@ -612,10 +736,13 @@ PropDefinitions:
   cancer_diagnosis_disease_morphology:
     Desc: <The ICD-O-3 code which identifies the specific appearance of cells and tissues (normal and abnormal) used to define the presence and nature of disease.> This list type property accepts multiple values for participants diagnosed with more than one type of cancer, provided that each disease morphology is represented by a valid ICD-O-3 code. In such cases, within the data loading file for the Participant node, the codes for each disease morphology reported as being associated with a single study participant must be separated from one another using the pipe (|) character. <br>CDE ID = 13606049
     Term:
-      - Origin: TBD
-        Code: '13606049' #'4723846' # updated 04-11-25
+      - Origin: caDSR
+        Code: '13606049' #'4723846' i.e. NCI CTEP Simplified Disease Classification Terminology MedDRA Version 10 Code # updated 04-11-25
         Value: Diagnosis Disease ICD-O-3 Morphology Code
-        Version: '1' # ?    
+        Version: '2'
+        Tags:
+          Provenance: Ped/CCDI
+          Labeled: Cancer Type by ICD-O Disease Morphology
     Src: Data Submitter(s)
     Type:
       value_type: list
@@ -624,10 +751,13 @@ PropDefinitions:
   age_at_enrollment:
     Desc: <The age in days of the subject when the subject enrolled in the study.> The age of the participant as of enrollment, measured in days. <br>CDE ID = 15742605
     Term:
-      - Origin: TBD
-        Code: '15742605' # formerly '12299548' updated 04-11-25
+      - Origin: caDSR
+        Code: '15742605' # formerly '12299548' as updated 04-11-25
         Value: Subject Age in Days at Enrollment Count # formerly Subject Age of Enrollment Day Count
         Version: '1'
+        Tags:
+          Provenance: Ped/CCDC
+          Labeled: Age at Enrollment
     Src: Data Submitter(s)
     Type:
       units:
@@ -635,12 +765,14 @@ PropDefinitions:
       value_type: number
     Req: 'Yes'
   age_at_first_cancer_diagnosis:
-    Desc: <The age (in days) of the participant when the participant was first diagnosed with cancer.> The age of the participant as of first diagnosis of cancer, measured in days. <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: <The age (in days) of the participant when the participant was first diagnosed with cancer.> The age of the participant as of first diagnosis of cancer, measured in days. <br>CDE ID = 16991497
     Term:
-      - Origin: x
-        Code: 'y' # TBD 04-11-25
-        Value: ~ Subject Age in Days at First Diagnosis Count
+      - Origin: caDSR
+        Code: '16991497'
+        Value: Subject Age in Days at First Diagnosis Count
         Version: '1'
+        Tags:
+          Provenance: CRDC/PSDC
     Src: Data Submitter(s)
     Type:
       units:
@@ -659,10 +791,13 @@ PropDefinitions:
   race:
     Desc: <The text for reporting information about race based on the Office of Management and Budget (OMB) categories.> <br>CDE ID = 2192199
     Term:
-      - Origin: caDSR - OMB/NCI Standard
+      - Origin: caDSR
         Code: '2192199' # verified 04-11-25
         Value: Race Category Text
         Version: '1'
+        Tags:
+          Provenance: NCI/CRDC Standard
+          Labeled: Race
     Src: Data Submitter(s)
     Type:
       value_type: list
@@ -679,10 +814,13 @@ PropDefinitions:
   ethnicity:
     Desc: <The text for reporting information about ethnicity based on the Office of Management and Budget (OMB) categories.> <br>CDE ID = 2192217
     Term:
-      - Origin: caDSR - OMB/NCI Standard
+      - Origin: caDSR
         Code: '2192217' # verified 04-11-25
         Value: Ethnic Group Category Text
         Version: '2'
+        Tags:
+          Provenance: NCI/CRDC Standard
+          Labeled: Ethnicity
     Src: Data Submitter(s)
     Enum: # now fully aligned with the acceptable values for the corresponding CDE
       - Hispanic or Latino
@@ -694,10 +832,13 @@ PropDefinitions:
   sex:
     Desc: <A textual description of a person's sex at birth.> CDE ID = 7572817
     Term:
-      - Origin: caDSR - NCI Standards
+      - Origin: caDSR
         Code: '7572817'  # verified 04-11-25
-        Value: Person Sex at Birth Category 
-        Version: '2'
+        Value: Person Sex at Birth Category
+        Version: '3'
+        Tags:
+          Provenance: NCI/CRDC Standard
+          Labeled: Sex
     Src: Data Submitter(s)
     Enum: # now fully aligned with the acceptable values for the corresponding CDE
       - Female
@@ -708,10 +849,12 @@ PropDefinitions:
   # height:
   #   Desc: <The number that describes the vertical distance of an individual.> The height of the participant as of enrollment, measured in cm. <br>CDE ID = 2179643
   #   Term:
-  #     - Origin: caDSR- CSAERS/NCI Standard
+  #     - Origin: caDSR
   #       Code: '2179643'
   #       Value: Person Height Value
   #       Version: '4'
+  #       Tags:
+  #         Provenance: NCI/CRDC Standard
   #   Src: Data Submitter(s)
   #   Type:
   #     units:
@@ -719,13 +862,14 @@ PropDefinitions:
   #     value_type: number
   #   Req: Preferred
   # weight:
-  #   Desc: <The number that describes the vertical force exerted by the mass of an individual as a result of gravity.> The weight of the participant as of enrollment,
-  #     measured in kg. <br>CDE ID = 2179689
+  #   Desc: <The number that describes the vertical force exerted by the mass of an individual as a result of gravity.> The weight of the participant as of enrollment, measured in kg. <br>CDE ID = 2179689
   #   Term:
-  #     - Origin: caDSR - CSAERS/NCI Standard
+  #     - Origin: caDSR
   #       Code: '2179689'
   #       Value: Person Weight Value
   #       Version: '4'
+  #       Tags:
+  #         Provenance: NCI/CRDC Standard
   #   Src: Data Submitter(s)
   #   Type:
   #     units:
@@ -735,10 +879,12 @@ PropDefinitions:
   # body_surface_area:
   #   Desc: <The calculated numerical quantity that represents the 2-dimensional extent of the body surface relating height to weight.> The body surface area of the participant as of enrollment, mathematically derived from the participant's height and weight, and expressed in square meters. <br>CDE ID = 653
   #   Term:
-  #     - Origin: caDSR - CTEP
+  #     - Origin: caDSR
   #       Code: '653'
   #       Value: Person Body Surface Area Value
   #       Version: '6'
+  #       Tags:
+  #         Provenance: CTEP/NCI Standard
   #   Src: Data Submitter(s)
   #   Type:
   #     units:
@@ -746,42 +892,50 @@ PropDefinitions:
   #     value_type: number
   #   Req: Preferred
   # bmi:
-  #   Desc: text
+  #   Desc: text. <br>CDE ID = 2006410
   #   Term:
   #     - Origin: caDSR
-  #       Code: 'code/ID'
-  #       Value: Data Element Name  
+  #       Code: '2006410'
+  #       Value: Person Body Mass Index Value
+  #       Version: '3'
+  #       Tags:
+  #         Provenance: NCI/CRDC Standard
   #   Src: Data Submitter(s)
   #   Type: number
   #   Req: 'Yes'
   # occupation:
   #   Desc: <The occupation/job category of a person.> <br>CDE ID = 6617540
   #   Term:
-  #     - Origin: caDSR - NCIP
+  #     - Origin: caDSR
   #       Code: '6617540'
   #       Value: Person Occupation Category
   #       Version: '1'
+  #       Tags:
+  #         Provenance: NCIP
   #   Src: Data Submitter(s)
   #   Type: string
   #   Req: Preferred
   # income:
   #   Desc: <The amount of earnings made by a family in a year.> <br>CDE ID = 14834966
   #   Term:
-  #     - Origin: caDSR - CTDC
+  #     - Origin: caDSR
   #       Code: '14834966'
   #       Value: Person Annual Household Income Text
   #       Version: '1'
+  #       Tags:
+  #         Provenance: CRDC
   #   Src: Data Submitter(s)
   #   Type: string
   #   Req: Preferred
   # highest_level_of_education:
-  #   Desc: <The subdivision that summarizes the highest level of education attained by a person.> An indication as to the highest level of education attained by
-  #     the participant. <br>CDE ID = 2681552
+  #   Desc: <The subdivision that summarizes the highest level of education attained by a person.> An indication as to the highest level of education attained by the participant. <br>CDE ID = 2681552
   #   Term:
-  #     - Origin: caDSR - NCI Standards (NCIP)
+  #     - Origin: caDSR
   #       Code: '2681552'
   #       Value: Person Education Level Summary Type
   #       Version: '1'
+  #       Tags:
+  #         Provenance: NCIP
   #   Src: Data Submitter(s)
   #   Enum: # Currently reflective only of the values used by the CMB
   #     - No formal education
@@ -819,10 +973,12 @@ PropDefinitions:
   ncbi_taxonomy_id: # participant prefix to prevent property duplication will be removed once the study_demographic node is retired out
     Desc: A label provided by NCBI Taxonomy Database (https://www.ncbi.nlm.nih.gov/taxonomy/),  which uniquely identifies group or category, at any level, in a system for classifying plants or animals (including humans) providing ranked categories for the classification of organisms according to their suspected evolutionary relationships. For human study participants, the value of this ID must be stated as 9606. <br>CDE ID = 10543100
     Term:
-      - Origin: caDSR - CRDC
+      - Origin: caDSR
         Code: '10543100' # verified 04-11-25
         Value: Subject Taxonomy NCBI Identifier # formerly Subject National Center for Biotechnology Information Taxonomy Identifier Integer
         Version: '2'
+        Tags:
+          Provenance: CRDC
     Src: Data Submitter(s)
     Enum:
       - "9606"
@@ -830,33 +986,41 @@ PropDefinitions:
   # participant_ncbi_taxonomy_name:
   #   Desc: The textual label associated with a participant's organismal classification as captured in the National Center for Biotechnology Information (NCBI) Taxonomy standard nomenclature and classification repository.  <br>Supposedly enumerated but no permissible values specified. <br>CDE ID = 10543082
   #   Term:
-  #     - Origin: caDSR - CRDC
+  #     - Origin: caDSR
   #       Code: '10543082'
-  #       Value: Subject National Center for Biotechnology Information Taxonomy Name
+  #       Value: Subject Taxonomy NCBI Name # formerly Subject National Center for Biotechnology Information Taxonomy Name
   #         Text
   #       Version: '2'
+  #       Tags:
+  #         Provenance: CRDC
   #   Src: Data Submitter(s)
   #   Enum:
   #     - Homo sapiens
   #   Req: 'Yes'  
   # file properties
-  data_file_name:
+  data_file_name: #Tags completed through here as of 10.30pm 03-06-26
     Desc: The literal label for an electronic data file, inclusive of file extension(s). <br>CDE ID = 11284037
     Term:
-      - Origin: caDSR - CRDC
+      - Origin: caDSR
         Code: '11284037'
-        Value: Electronic Data File Name
+        Value: Data File Name Text # Electronic Data File Name
+        Version: '3'
+        Tags:
+          Provenance: NCI/CRDC Standard
+          Labeled: File Name
     Src: DSS
     Type: string
     Req: 'Yes'
-    Tags:
-      Labeled: File Name
   data_file_type:
     Desc: <The type of information contained in an electronic record.> A curated indicator as to the type of content represented by the data file <br>CDE ID = 14824731
     Term:
-      - Origin: caDSR - CTDC
+      - Origin: caDSR
         Code: '14824731'
-        Value: Electronic Data File Content Type
+        Value: Data File Content Category # Electronic Data File Content Type
+        Version: '2'
+        Tags:
+          Provenance: NCI/CRDC Standard
+          Labeled: File Type
     Src: FNL
     Enum:
       - Data Dictionary
@@ -867,56 +1031,66 @@ PropDefinitions:
       - Survey
       - More options to be added as needed
     Req: 'Yes'
-    Tags:
-      Labeled: File Type
   data_file_description:
     Desc: A free text field that can be used to document the content and other details about an electronic file that may not be captured elsewhere. <br>CDE ID = 11280338
     Term:
-      - Origin: caDSR - CRDC
+      - Origin: caDSR
         Code: '11280338'
-        Value: Electronic Data File Description Text  
+        Value: Data File Description Text # Electronic Data File Description Text
+        Version: '2'
+        Tags:
+          Provenance: NCI/CRDC Standard
+          Labeled: Description
     Src: DSS
     Type: string
     Req: 'Yes'
-    Tags:
-      Labeled: Description
   data_file_format:
     Desc: A defined organization or layout representing and structuring data in a computer file; the electronic format of the file, as derived during file validation <br>With the actual values of this property being loader derived, the acceptable values currently specified are in place only to support the generation of mock data <br>CDE ID = 11416926
     Term:
-      - Origin: caDSR - CRDC
+      - Origin: caDSR
         Code: '11416926'
-        Value: Electronic Data File Format Type  
+        Value: Data File Format Type # Electronic Data File Format Type
+        Version: '2'
+        Tags:
+          Provenance: NCI/CRDC Standard
+          Labeled: Format
     Src: DSS
     Type: string
     Req: 'Yes'
-    Tags:
-      Labeled: Format
   data_file_size:
     Desc: The measure, expressed in bytes, as to how much space a data file takes up on a storage medium. <br>CDE ID = 11479876
     Term:
-      - Origin: caDSR - CRDC
+      - Origin: caDSR
         Code: '11479876'
-        Value: Electronic Data File Size Integer  
+        Value: Data File Size Integer # Electronic Data File Size Integer
+        Version: '2'
+        Tags:
+          Provenance: NCI/CRDC Standard
+          Labeled: Size
     Src: DSS
-    Type: number
+    Type: integer
     Req: 'Yes'
-    Tags:
-      Labeled: Size
   data_file_checksum_value:
     Desc: A small-sized block of data derived from a file for the purpose of detecting errors that may have been introduced during file transmission and/or storage and used to verify data integrity. <br>CDE ID = 11480133
     Term:
-      - Origin: caDSR - CRDC
+      - Origin: caDSR
         Code: '11480133'
-        Value: Electronic Data File Checksum Value  
+        Value: Data File Checksum Value # Electronic Data File Checksum Value
+        Version: '2'
+        Tags:
+          Provenance: NCI/CRDC Standard
     Src: DSS
     Type: string
     Req: 'Yes'
   data_file_checksum_type:
     Desc: The method by which the file checksum was calculated. <br>CDE ID = 11475057
     Term:
-      - Origin: caDSR - CRDC
+      - Origin: caDSR
         Code: '11475057'
-        Value: Electronic Data File Checksum Type  
+        Value: Data File Checksum Type # Electronic Data File Checksum Type
+        Version: '2'
+        Tags:
+          Provenance: NCI/CRDC Standard
     Src: DSS
     Enum:
       - md5sum
@@ -926,9 +1100,12 @@ PropDefinitions:
   data_file_compression_status:
     Desc: The state of data when saved to storage space or during data transmission. <br>CDE ID = 11387114
     Term:
-      - Origin: caDSR-CRDC
+      - Origin: caDSR
         Code: '11387114'
-        Value: Electronic Data File Compression Type  
+        Value: Data File Compression Status # Electronic Data File Compression Type
+        Version: '2'
+        Tags:
+          Provenance: NCI/CRDC Standard
     Src: DSS
     Enum:
       - Compressed
@@ -938,9 +1115,13 @@ PropDefinitions:
   data_file_uuid:
     Desc: <A unique sequence of characters used to identify the contents of an electronic record.> <br>CDE ID = 14826100
     Term:
-      - Origin: caDSR - CTDC
+      - Origin: caDSR
         Code: '14826100'
-        Value: Electronic Data File Content Unique Identifier 
+        Value: Data File Content Unique Identifier # Electronic Data File Content Unique Identifier
+        Version: '1'
+        Tags:
+          Provenance: NCI/CRDC Standard
+          Template: 'No'
     Src: FNL
     Type: string
     Req: 'Yes'
@@ -948,18 +1129,25 @@ PropDefinitions:
   data_file_location:
     Desc: <The specification of a node (file or directory) in a hierarchical file system where an electronic file is located.> The specific location within the S3 storage bucket at which the file is stored, expressed in terms of a unique url <br>CDE ID = 11556141
     Term:
-      - Origin: caDSR - CDS
+      - Origin: caDSR
         Code: '11556141'
-        Value: Electronic File Pathname Text    
+        Value: Data File Content Unique Identifier # Electronic File Pathname Text
+        Version: '2'
+        Provenance: CRDC/CDS
+        Template: 'No'
     Src: FNL
     Type: string
     Req: 'Yes'
   data_file_access_control:
-    Desc: An indicator as to the level of access control to which a data file is subject. <br>NOT CURRENTLY ASSIGNED ANY CDE
+    Desc: An indicator as to the level of access control to which a data file is subject. <br>CDE ID = 11555664
     Term:
       - Origin: caDSR
-        Code: 'code/ID'
-        Value: Data Element Name  
+        Code: '11555664'
+        Value: Data File Access Level Text
+        Version: '2'
+        Tags:
+          Provenance: CRDC/GC
+          Labeled: Access Control
     Src: Data Submitter(s)
     Enum:
       - Controlled Access

--- a/model-desc/popsci-model-props.yml
+++ b/model-desc/popsci-model-props.yml
@@ -143,7 +143,7 @@ PropDefinitions:
     Req: 'Yes'
     Key: true
   study_id:
-    Desc: <A unique identifier assigned to a clinical study.> Any external identifier(s) by which the study in question is already known. <br>CDE ID = 5054234
+    Desc: <A unique identifier assigned to a clinical study.> Any external identifier(s) by which the study in question is already known. <br>CDE ID = 16979764 # formerly 5054234
     Term:
       - Origin: caDSR
         Code: '16979764'
@@ -267,7 +267,7 @@ PropDefinitions:
         Version: '1'
         Tags:
           Provenance: Ped/CCDI
-    Src: Data Submitter(s)c
+    Src: Data Submitter(s)
     Type: string # this accomodates use of the the term Ongoing for studies that are still active
     Req: 'Yes'
   biospecimen_collection:
@@ -287,7 +287,7 @@ PropDefinitions:
     Req: Preferred
   # study_personnel properties
   study_personnel_record_id:  
-    Desc: <A unique sequence of characters used to identify a linkage between related records.> A unique identifier of each each study personnel record associated with the study in question, used to identify the appropriate study personnel record(s) during data loading and/or record modification. The value of this record ID also dictates the order in which study personnel are listed within the application's UI. <br>CDE ID = 14822135
+    Desc: <A unique sequence of characters used to identify a linkage between related records.> A unique identifier of each study personnel record associated with the study in question, used to identify the appropriate study personnel record(s) during data loading and/or record modification. The value of this record ID also dictates the order in which study personnel are listed within the application's UI. <br>CDE ID = 14822135
     Term:
       - Origin: caDSR
         Code: '14822135'
@@ -352,7 +352,7 @@ PropDefinitions:
     Type: string
     Req: 'Yes'
   person_role:
-    Desc: <The text that describes the distinguishable characteristics of the action or activity assigned to or required or expected of a person in a formal association with a group or organization.> An indicator as to the role(s) and/or responsibilities of each individual responsible for or directly involved in the conduct and/or analysis of the clinical trial or research project. Each such individual must have at least one specified role, but any given indivdual may be assigned multiple roles for the study in question. Within the data loading file, multiple roles assigned to a single individual must be separated from one another using the pipe (|) character. <br>CDE ID = 2201713
+    Desc: <The text that describes the distinguishable characteristics of the action or activity assigned to or required or expected of a person in a formal association with a group or organization.> An indicator as to the role(s) and/or responsibilities of each individual responsible for or directly involved in the conduct and/or analysis of the clinical trial or research project. Each such individual must have at least one specified role, but any given individual may be assigned multiple roles for the study in question. Within the data loading file, multiple roles assigned to a single individual must be separated from one another using the pipe (|) character. <br>CDE ID = 2201713
     Term:
       - Origin: caDSR 
         Code: '2201713'
@@ -663,7 +663,7 @@ PropDefinitions:
       - Vital Status
     Req: 'Yes'
   data_collection_category_annotation_count: # subject to confirmation from the working group, this property will morph into a binary Yes versus No indicator as to whether the data collection category in question was examined or not, given that the reporting of the number of variables per data collection category will be too burdensome
-    Desc: Pending additional data model and application code changes, this property functions as a binary indicator as to whether variables associated with any given data collection were assessed or not. A value of 0 should be used to indicate that no variables associated with a given data collection category were assessed. Whereas regradless of how many variables within a data collection category were assessed, a value of 1 should be used simply to indicate that variables associated with a given data collection category were indeed assessed. <br>CDE ID = 16991477
+    Desc: Pending additional data model and application code changes, this property functions as a binary indicator as to whether variables associated with any given data collection were assessed or not. A value of 0 should be used to indicate that no variables associated with a given data collection category were assessed. Whereas regardless of how many variables within a data collection category were assessed, a value of 1 should be used simply to indicate that variables associated with a given data collection category were indeed assessed. <br>CDE ID = 16991477
     Term:
       - Origin: caDSR
         Code: '16991477'
@@ -719,7 +719,7 @@ PropDefinitions:
       - 'No'
       - 'Yes'
   cancer_diagnosis_primary_site:
-    Desc: <The location within the body from where the disease of interest originated as captured in the Uberon identifier.> More specifically, primary disease sites must be reported in the form of the appripriate Uberon codes. This list type property accepts multiple values for participants diagnosed with more than one type of cancer, provided that each primary disease site is specified by a valid Uberon code. In such cases, within the data loading file for the Participant node, the codes for each primary disease site reported asd being assocaited with a single study participant must be separated from one another using the pipe (|) character.  <br>CDE = 14883047
+    Desc: <The location within the body from where the disease of interest originated as captured in the Uberon identifier.> More specifically, primary disease sites must be reported in the form of the appropriate Uberon codes. This list type property accepts multiple values for participants diagnosed with more than one type of cancer, provided that each primary disease site is specified by a valid Uberon code. In such cases, within the data loading file for the Participant node, the codes for each primary disease site reported as being associated with a single study participant must be separated from one another using the pipe (|) character.  <br>CDE ID = 14883047
     Term:
       - Origin: caDSR
         Code: '14883047'

--- a/model-desc/popsci-model-props.yml
+++ b/model-desc/popsci-model-props.yml
@@ -78,19 +78,25 @@ PropDefinitions:
   program_name:
     Desc: <The narrative title used to refer to a broad framework (an administrative umbrella) of goals under which related projects or other research activities are grouped. Example - Clinical Proteomic Tumor Analysis.> <br>CDE ID = 11444542 
     Term:
-      - Origin: caDSR - CRDC
+      - Origin: caDSR
         Code: '11444542'
-        Value: Program Name Text  
-    Src: DSS
+        Value: Program Name Text 
+        Version: '3'
+        Tags:
+          Provenance: CRDC
+    Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
   program_short_name:
     Desc: <An acronym or abbreviated form of the title of a broad framework of goals under which related projects or other research activities are grouped. For example, CPTAC.> <br>CDE ID = 11459801 <br>This property is used as the key via which child records, e.g. project and/or study/trial records, can be associated with the appropriate program during data loading, and to identify the correct records during data updates.
     Term:
-      - Origin: caDSR - CRDC
+      - Origin: caDSR
         Code: '11459801'
-        Value: Program Short Name Text  
-    Src: DSS
+        Value: Program Short Name Text
+        Version: '3'
+        Tags:
+          Provenance: CRDC
+    Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
     Key: true
@@ -171,7 +177,7 @@ PropDefinitions:
   study_description: 
     Desc: <A textual description of the study, with components such as objectives or goals.> A narrative description of the study outlining its design, conduct and data collection goals. <br>CDE ID = 16188024
     Term:
-      - Origin: caDSR - Ped/CCDI
+      - Origin: caDSR
         Code: '16188024'
         Value: Research Activity Study Description Text
         Version: '1'
@@ -405,18 +411,24 @@ PropDefinitions:
   associated_link_name:  
     Desc: <The words by which the linkage between related records is known.> The exact text to be displayed within the UI where it functions as an intuitive identifier of any given link associated with the study/trial in question. <br>CDE ID = 14822136
     Term:
-      - Origin: caDSR - CTDC
+      - Origin: caDSR
         Code: '14822136'
         Value: Data Record Link Identifier Name
+        Version: '1'
+        Tags:
+          Provenance: CTDC
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
   associated_link_url:
     Desc: <The global address of the linkage between related records on the World Wide Web.> The url to which an end user will be redirected upon selection of the corresponding link name displayed within the UI. <br>CDE ID = 14822140
     Term:
-      - Origin: caDSR - CTDC
+      - Origin: caDSR
         Code: '14822140'
         Value: Clinical Study Record Link Identifier URL Text
+        Version: '1'
+        Tags:
+          Provenance: CTDC
     Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
@@ -574,25 +586,25 @@ PropDefinitions:
         Version: '1'
         Tags:
           Provenance: CRDC/CTDC
-    Src: PSc
+    Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
     Key: true
   data_collection_category:
     Desc: text here <br>CDE ID = 16990979
-    Term:
-      - Origin: caDSR
-        Code: '16990979'
-        Value: Research Activity Data Collection Category text
-        Version: '1'
-        Tags:
-          Provenance: CRDC/PSDC
-          Labeled: Data Collection Categories
+    # Term:
+    #   - Origin: caDSR
+    #     Code: '16990979'
+    #     Value: Research Activity Data Collection Category text
+    #     Version: '1'
+    #     Tags:
+    #       Provenance: CRDC/PSDC
+    #       Labeled: Data Collection Categories
     Src: PSc
     Enum: # n=71
       - Age # Demographics / Lifestyle / Life events / Quality of life
       - Biological Sex
-      - Sexual Orientation and Gender Identity
+      #- Sexual Orientation and Gender Identity
       - Ethnicity and Race
       - Education Level
       - Employment Status
@@ -662,21 +674,25 @@ PropDefinitions:
       - Injury, Poisoning, Certain Other Consequences of External Causes
       - Vital Status
     Req: 'Yes'
+    Tags:
+      Labeled: Data Collection Categories
   data_collection_category_annotation_count: # subject to confirmation from the working group, this property will morph into a binary Yes versus No indicator as to whether the data collection category in question was examined or not, given that the reporting of the number of variables per data collection category will be too burdensome
     Desc: Pending additional data model and application code changes, this property functions as a binary indicator as to whether variables associated with any given data collection were assessed or not. A value of 0 should be used to indicate that no variables associated with a given data collection category were assessed. Whereas regardless of how many variables within a data collection category were assessed, a value of 1 should be used simply to indicate that variables associated with a given data collection category were indeed assessed. <br>CDE ID = 16991477
-    Term:
-      - Origin: caDSR
-        Code: '16991477'
-        Value: Research Activity Data Collection Category Annotation Count
-        Version: '1'
-        Tags:
-          Provenance: CRDC/PSDC
-          Labeled: Assessed
-    Src: FNL
+    # Term:
+    #   - Origin: caDSR
+    #     Code: '16991477'
+    #     Value: Research Activity Data Collection Category Annotation Count
+    #     Version: '1'
+    #     Tags:
+    #       Provenance: CRDC/PSDC
+    #       Labeled: Assessed
+    Src: Data Submitter(s)
     Enum:
       - "0"
       - "1"
     Req: 'Yes'
+    Tags:
+      Labeled: Assessed
   # data_collection_category_assessed: # per working group discussions, this property now replaces the data_collection_annotation_count property, providing a simple Yes versus No indicator as to whether the data collection category in question was examined or not
   #   Desc: text here <br>CDE ID = 16991478
   #   Term:
@@ -684,7 +700,7 @@ PropDefinitions:
   #       Code: '16991478'
   #       Value: Research Activity Data Collection Category Assessed Count
   #       Version: '1'
-  #   Src: FNL
+  #   Src: Data Submitter(s)
   #   Enum:
   #     - 'Yes'
   #     - 'No'
@@ -738,7 +754,7 @@ PropDefinitions:
     Desc: <The ICD-O-3 code which identifies the specific appearance of cells and tissues (normal and abnormal) used to define the presence and nature of disease.> This list type property accepts multiple values for participants diagnosed with more than one type of cancer, provided that each disease morphology is represented by a valid ICD-O-3 code. In such cases, within the data loading file for the Participant node, the codes for each disease morphology reported as being associated with a single study participant must be separated from one another using the pipe (|) character. <br>CDE ID = 13606049
     Term:
       - Origin: caDSR
-        Code: '13606049' #'4723846' i.e. NCI CTEP Simplified Disease Classification Terminology MedDRA Version 10 Code # updated 04-11-25
+        Code: '13606049' #  updated 04-11-25, formerly '4723846' i.e. NCI CTEP Simplified Disease Classification Terminology MedDRA Version 10 Code
         Value: Diagnosis Disease ICD-O-3 Morphology Code
         Version: '2'
         useNullCDE: 'Yes'
@@ -1010,7 +1026,7 @@ PropDefinitions:
         Tags:
           Provenance: NCI/CRDC Standard
           Labeled: File Name
-    Src: DSS
+    Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
   data_file_type:
@@ -1023,7 +1039,7 @@ PropDefinitions:
         Tags:
           Provenance: NCI/CRDC Standard
           Labeled: File Type
-    Src: FNL
+    Src: Data Submitter(s)
     Enum:
       - Data Dictionary
       - Data Guide
@@ -1043,7 +1059,7 @@ PropDefinitions:
         Tags:
           Provenance: NCI/CRDC Standard
           Labeled: Description
-    Src: DSS
+    Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
   data_file_format:
@@ -1056,7 +1072,7 @@ PropDefinitions:
         Tags:
           Provenance: NCI/CRDC Standard
           Labeled: Format
-    Src: DSS
+    Src: System-generated
     Type: string
     Req: 'Yes'
   data_file_size:
@@ -1069,7 +1085,7 @@ PropDefinitions:
         Tags:
           Provenance: NCI/CRDC Standard
           Labeled: Size
-    Src: DSS
+    Src: Data Submitter(s)
     Type: integer
     Req: 'Yes'
   data_file_checksum_value:
@@ -1081,7 +1097,7 @@ PropDefinitions:
         Version: '2'
         Tags:
           Provenance: NCI/CRDC Standard
-    Src: DSS
+    Src: Data Submitter(s)
     Type: string
     Req: 'Yes'
   data_file_checksum_type:
@@ -1093,7 +1109,7 @@ PropDefinitions:
         Version: '2'
         Tags:
           Provenance: NCI/CRDC Standard
-    Src: DSS
+    Src: Data Submitter(s)
     Enum:
       - md5sum
       - sha1
@@ -1108,7 +1124,7 @@ PropDefinitions:
         Version: '2'
         Tags:
           Provenance: NCI/CRDC Standard
-    Src: DSS
+    Src: Data Submitter(s)
     Enum:
       - Compressed
       - Uncompressed
@@ -1124,7 +1140,7 @@ PropDefinitions:
         Tags:
           Provenance: NCI/CRDC Standard
           Template: 'No'
-    Src: FNL
+    Src: System-generated
     Type: string
     Req: 'Yes'
     Key: true
@@ -1137,7 +1153,7 @@ PropDefinitions:
         Version: '2'
         Provenance: CRDC/CDS
         Template: 'No'
-    Src: FNL
+    Src: System-generated
     Type: string
     Req: 'Yes'
   data_file_access_control:

--- a/model-desc/popsci-model-props.yml
+++ b/model-desc/popsci-model-props.yml
@@ -725,6 +725,7 @@ PropDefinitions:
         Code: '14883047'
         Value: Primary Disease Anatomic Site UBERON Identifier
         Version: '1'
+        useNullCDE: 'Yes'
         Tags:
           Provenance: CRDC Standard
           Labeled: Cancer Type by Uberon Primary Disease Site
@@ -740,6 +741,7 @@ PropDefinitions:
         Code: '13606049' #'4723846' i.e. NCI CTEP Simplified Disease Classification Terminology MedDRA Version 10 Code # updated 04-11-25
         Value: Diagnosis Disease ICD-O-3 Morphology Code
         Version: '2'
+        useNullCDE: 'Yes'
         Tags:
           Provenance: Ped/CCDI
           Labeled: Cancer Type by ICD-O Disease Morphology

--- a/model-desc/popsci-model.yml
+++ b/model-desc/popsci-model.yml
@@ -72,7 +72,7 @@ Nodes:
       - person_institution # CDE ID = 16990046
       - person_role # CDE ID = 2201713
   associated_link:
-    Desc: The Associated Link node contains the properties required to associate multiple links to additional information about any given study with the appropriate study record, and to define an inuitive label via which each link will be diplayed within the UI. 
+    Desc: The Associated Link node contains the properties required to associate multiple links to additional information about any given study with the appropriate study record, and to define an intuitive label via which each link will be displayed within the UI. 
     Tags:
       Category: study
       Assignment: core
@@ -98,7 +98,7 @@ Nodes:
       - digital_object_id # per CTDC, CDE ID = 15915370
       - pubmed_id # per CTDC, CDE ID = 15915377
   study_country:
-    Desc: The Study Country node contains only a single property via which potentially lengthy lists of countires from which study participants were included can be associated with the study in question, using data loading files of minimal complexity.
+    Desc: The Study Country node contains only a single property via which potentially lengthy lists of countries from which study participants were included can be associated with the study in question, using data loading files of minimal complexity.
     Tags:
       Category: study
       Assignment: core
@@ -108,7 +108,7 @@ Nodes:
       - study_country_record_id # CDE ID = 14822135
       - study_country # CDE ID = 16990793
   study_state_province_territory:
-    Desc: The Study State/Province/Territory node contains only a single proerty via which potentially lengthy lists of states and/or provinces and/or territories from which study participants were included can be associated with the study in question, using data loading files of minimal complexity.
+    Desc: The Study State/Province/Territory node contains only a single property via which potentially lengthy lists of states and/or provinces and/or territories from which study participants were included can be associated with the study in question, using data loading files of minimal complexity.
     Tags:
       Category: study
       Assignment: core
@@ -130,7 +130,7 @@ Nodes:
       - data_collection_category_annotation_count # the number of annotations per data collection category # CDE ID = 16991477 but property will ultimately be deprecated, and superseded by data_collection_category_assessed as noted below
       #- data_collection_category_assessed  # CDE ID = 16991478 and this property will supersede the current data_collection_category_annotation_count as noted above
   participant:
-    Desc: The Particpant node is comprised of the properties which define and characterize each study participant
+    Desc: The Participant node is comprised of the properties which define and characterize each study participant
     Tags:
       Category: case
       Assignment: core
@@ -146,7 +146,7 @@ Nodes:
       #- year_of_birth # NOT CURRENTLY ASSIGNED ANY CDE
       - race # per CTDC, CDE ID = 2192199
       - ethnicity # per CTDC, CDE ID = 2192217
-      - sex # per CTDC, CDE ID = 7572817)
+      - sex # per CTDC, CDE ID = 7572817
       #- height # per CTDC, CDE ID = 2179643
       #- weight # per CTDC, CDE ID = 2179689
       #- body_surface_area # per CTDC, CDE ID = 653

--- a/model-desc/popsci-model.yml
+++ b/model-desc/popsci-model.yml
@@ -47,16 +47,16 @@ Nodes:
     Props:
       - study_name # CDE ID = 11459810
       - study_short_name # CDE ID = 11459812
-      - study_id # CDE ID = 5054234
-      - dbgap_accession_id # NOT CURRENTLY ASSIGNED ANY CDE
-      - study_description # CDE ID = 3444002
-      - study_design # NOT CURRENTLY ASSIGNED ANY CDE
-      - study_status # NOT CURRENTLY ASSIGNED ANY CDE
-      - enrollment_beginning_year # NOT CURRENTLY ASSIGNED ANY CDE
-      - enrollment_ending_year # NOT CURRENTLY ASSIGNED ANY CDE
-      - study_beginning_year # NOT CURRENTLY ASSIGNED ANY CDE
-      - study_ending_year # NOT CURRENTLY ASSIGNED ANY CDE
-      - biospecimen_collection # NOT CURRENTLY ASSIGNED ANY CDE
+      - study_id # CDE ID = 16979764
+      - dbgap_accession_id # CDE ID = 11524544
+      - study_description # CDE ID = 16188024
+      - study_design # CDE ID = 16979765
+      - study_status # CDE ID = 15607838
+      - enrollment_beginning_year # CDE ID = 16979766
+      - enrollment_ending_year # CDE ID = 16979767
+      - study_beginning_year # CDE ID = 15607845
+      - study_ending_year # CDE ID = 15607913
+      - biospecimen_collection # CDE ID = 16979768
   study_personnel:
     Desc: The Study Personnel node contains properties which identify the individuals most directly involved in the conduct of any given study and/or the analysis of the data generated, and which indicate the specific role(s) of each member of the study team.
     Tags:
@@ -69,7 +69,7 @@ Nodes:
       - person_first_name # CDE ID = 2179589
       - person_last_name # CDE ID = 2179591
       - person_middle_name # CDE ID = 2179590
-      - person_institution # NOT CURRENTLY ASSIGNED ANY CDE
+      - person_institution # CDE ID = 16990046
       - person_role # CDE ID = 2201713
   associated_link:
     Desc: The Associated Link node contains the properties required to associate multiple links to additional information about any given study with the appropriate study record, and to define an inuitive label via which each link will be diplayed within the UI. 
@@ -91,12 +91,12 @@ Nodes:
       Template: 'Yes'
     Props:
       - publication_record_id # CDE ID = 14822135
-      - publication_title # NOT CURRENTLY ASSIGNED ANY CDE
-      - authorship # NOT CURRENTLY ASSIGNED ANY CDE
-      - year_of_publication # NOT CURRENTLY ASSIGNED ANY CDE
-      - journal_citation # NOT CURRENTLY ASSIGNED ANY CDE
-      - digital_object_id # NOT CURRENTLY ASSIGNED ANY CDE
-      - pubmed_id # NOT CURRENTLY ASSIGNED ANY CDE
+      - publication_title # per CTDC, CDE ID = 16078531
+      - authorship # per CTDC, CDE ID = 16081468
+      - year_of_publication # per CTDC, CDE ID = 16081475
+      - journal_citation # per CTDC, CDE ID = 16081476
+      - digital_object_id # per CTDC, CDE ID = 15915370
+      - pubmed_id # per CTDC, CDE ID = 15915377
   study_country:
     Desc: The Study Country node contains only a single property via which potentially lengthy lists of countires from which study participants were included can be associated with the study in question, using data loading files of minimal complexity.
     Tags:
@@ -106,7 +106,7 @@ Nodes:
       Template: 'Yes'
     Props:
       - study_country_record_id # CDE ID = 14822135
-      - study_country # NOT CURRENTLY ASSIGNED ANY CDE
+      - study_country # CDE ID = 16990793
   study_state_province_territory:
     Desc: The Study State/Province/Territory node contains only a single proerty via which potentially lengthy lists of states and/or provinces and/or territories from which study participants were included can be associated with the study in question, using data loading files of minimal complexity.
     Tags:
@@ -116,19 +116,19 @@ Nodes:
       Template: 'Yes'
     Props:
       - study_state_record_id # CDE ID = 14822135
-      - study_state_province_territory # NOT CURRENTLY ASSIGNED ANY CDE
+      - study_state_province_territory # CDE ID = 16990818
   data_collection:
     Desc: The Data Collection node is comprised of the properties required to describe the nature of the data being gathered by any given study, and to define the extent to which each data collection category was covered.
     Tags:
       Category: study
       Assignment: core
       Class: primary
-      Template: 'Yes'
+      Template: 'No'
     Props:  
       - data_collection_record_id # CDE ID = 14822135
-      - data_collection_category # for example Mental Health Assessments, Cardiovascular Health Assessments, Smoking History, etc., all per CV # NOT CURRENTLY ASSIGNED ANY CDE
-      - data_collection_category_annotation_count # the number of annotations per data collection category # NOT CURRENTLY ASSIGNED ANY CDE but property will ultimately be deprecated, and superseded by data_collection_category_assessed as noted below
-      #- data_collection_category_assessed  # NOT CURRENTLY ASSIGNED ANY CDE and this property will supersede the current data_collection_category_annotation_count as noted above
+      - data_collection_category # for example Mental Health Assessments, Cardiovascular Health Assessments, Smoking History, etc., all per CV # CDE ID = 16990979
+      - data_collection_category_annotation_count # the number of annotations per data collection category # CDE ID = 16991477 but property will ultimately be deprecated, and superseded by data_collection_category_assessed as noted below
+      #- data_collection_category_assessed  # CDE ID = 16991478 and this property will supersede the current data_collection_category_annotation_count as noted above
   participant:
     Desc: The Particpant node is comprised of the properties which define and characterize each study participant
     Tags:
@@ -138,11 +138,11 @@ Nodes:
       Template: 'Yes'
     Props:
       - participant_id # per CTDC, CDE ID = 12220014
-      - participant_case_indicator # NOT CURRENTLY ASSIGNED ANY CDE
+      - participant_case_indicator # CDE ID = 16991485
       - cancer_diagnosis_primary_site # CDE ID = 14883047 as noted here 12-05-25
       - cancer_diagnosis_disease_morphology # CDE ID = 13606049 as noted here 12-05-25
-      - age_at_enrollment # per CTDC, CDE = 12299548
-      - age_at_first_cancer_diagnosis # NOT CURRENTLY ASSIGNED ANY CDE
+      - age_at_enrollment # CDE ID = 15742605 formerly per CTDC, CDE = 12299548
+      - age_at_first_cancer_diagnosis # CDE ID = 16991497
       #- year_of_birth # NOT CURRENTLY ASSIGNED ANY CDE
       - race # per CTDC, CDE ID = 2192199
       - ethnicity # per CTDC, CDE ID = 2192217
@@ -150,8 +150,8 @@ Nodes:
       #- height # per CTDC, CDE ID = 2179643
       #- weight # per CTDC, CDE ID = 2179689
       #- body_surface_area # per CTDC, CDE ID = 653
-      #- body_mass_index # NOT CURRENTLY ASSIGNED ANY CDE
-      #- occupation # per CTDC, CDE ID = 6617540
+      #- body_mass_index # CDE ID = 2006410
+      #- occupation # formerly per CTDC, CDE ID = 6617540
       #- income # per CTDC, CDE ID = 14834966
       #- highest_level_of_education # per CTDC, CDE ID = 2681552
       #- tobacco_usage # NOT CURRENTLY ASSIGNED ANY CDE
@@ -178,7 +178,7 @@ Nodes:
       - data_file_compression_status # CDE ID = 11387114
       - data_file_uuid # CDE ID = 14826100
       - data_file_location # CDE ID = 11556141
-      - data_file_access_control # NOT CURRENTLY ASSIGNED ANY CDE
+      - data_file_access_control # CDE ID = 11555664
 Relationships:
   belongs_to:
     Mul: many_to_one

--- a/model-desc/version.md
+++ b/model-desc/version.md
@@ -1,0 +1,6 @@
+## Release Notes - Population Sciences Data Commons (PSDC)
+### Data Model version 1.0.0
+Release Date: 03/23/26  
+
+Publication of this, the first official version of the Data Model, is being co-ordinated with the initial "soft-launch" release of the Population Sciences Data Commons repository.
+


### PR DESCRIPTION
MVM v1.0.0 for MVP+ release: added some final polish

Within the popsci-model.yml file:

1. Updated the "quick view" CDE IDs noted for each property to align them with the full CDE references within the props file
2. Set Template to No for the Data Collection node

Within the popsci-model-props.yml file:

1. Added, updated or corrected numerous CDE references
2. Added CDE Version numbers
3. Added Provenance tags
4. Set Template to No for certain Data File properties