### PR TITLE
Minimum Viable Model v1.0.0 - "Quick View" CDE IDs re-instated

### DIFF
--- a/model-desc/popsci-model-props.yml
+++ b/model-desc/popsci-model-props.yml
@@ -1031,7 +1031,7 @@ PropDefinitions:
     Type: string
     Req: 'Yes'
   data_file_type:
-    Desc: <The type of information contained in an electronic record.> A curated indicator as to the type of content represented by the data file.
+    Desc: <The type of information contained in an electronic record.> A curated indicator as to the type of content represented by the data file. <br>CDE ID = 14824731
     # Term:
     #   - Origin: caDSR
     #     Code: '14824731'
@@ -1160,7 +1160,7 @@ PropDefinitions:
     Type: string
     Req: 'Yes'
   data_file_access_control:
-    Desc: An indicator as to the level of access control to which a data file is subject.
+    Desc: An indicator as to the level of access control to which a data file is subject. <br>CDE ID = 11555664
     # Term:
     #   - Origin: caDSR
     #     Code: '11555664'


### PR DESCRIPTION
With their CDE references commented out, re-instated the original "quick view" CDE IDs for: data_file_type
data_file_access_control